### PR TITLE
Bump pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v2.0.0
+  rev: v2.1.0
   hooks:
   - id: trailing-whitespace
   - id: end-of-file-fixer
@@ -17,35 +17,35 @@ repos:
   - id: requirements-txt-fixer
   - id: fix-encoding-pragma
 - repo: https://github.com/pre-commit/mirrors-autopep8
-  rev: v1.4.2
+  rev: v1.4.3
   hooks:
   - id: autopep8
 - repo: https://github.com/asottile/reorder_python_imports
-  rev: v1.3.2
+  rev: v1.3.5
   hooks:
   - id: reorder-python-imports
     args: [--add-import, from __future__ import absolute_import, --add-import, from __future__ import unicode_literals, --add-import, from __future__ import print_function]
     exclude: ^setup\.py$
 - repo: https://github.com/asottile/pyupgrade
-  rev: v1.10.0
+  rev: v1.11.2
   hooks:
   - id: pyupgrade
 - repo: https://github.com/asottile/add-trailing-comma
-  rev: v0.7.1
+  rev: v0.7.2
   hooks:
   - id: add-trailing-comma
 - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-  rev: v1.1.3
+  rev: v1.2.2
   hooks:
   - id: pretty-format-yaml
     args: [--autofix, --indent, '2']
 - repo: https://github.com/Yelp/detect-secrets
-  rev: 0.10.4
+  rev: v0.12.0
   hooks:
   - id: detect-secrets
     args: [--baseline, .secrets.baseline]
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.641
+  rev: v0.670
   hooks:
   - id: mypy
     language_version: python3.6

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,6 +1,9 @@
 {
-  "exclude_regex": null,
-  "generated_at": "2018-10-30T14:48:48Z",
+  "exclude": {
+    "files": null,
+    "lines": null
+  },
+  "generated_at": "2019-02-13T10:15:57Z",
   "plugins_used": [
     {
       "base64_limit": 4.5,
@@ -18,5 +21,5 @@
     }
   ],
   "results": {},
-  "version": "0.10.4"
+  "version": "0.12.0"
 }


### PR DESCRIPTION
Bumping all pre-commit hooks in order to satisfy the internal requirements to open source the project.
We need to have the latest version of detect-secrets.
I found easier to run `pre-commit autoupdate && pre-commit run --all-files`` instead 