### PR TITLE
Add support for blacklisting rules

### DIFF
--- a/swagger_spec_compatibility/cli/__init__.py
+++ b/swagger_spec_compatibility/cli/__init__.py
@@ -11,7 +11,6 @@ from six import iteritems
 from swagger_spec_compatibility.cli import explain  # noqa: F401
 from swagger_spec_compatibility.cli import run  # noqa: F401
 from swagger_spec_compatibility.cli.common import cli_rules
-from swagger_spec_compatibility.rules import RuleRegistry
 from swagger_spec_compatibility.util import wrap
 
 
@@ -36,11 +35,19 @@ def parser():
     )
 
     rules = cli_rules()
-    parser.add_argument(
+    mutex_group = parser.add_mutually_exclusive_group()
+    mutex_group.add_argument(
         '-r', '--rules',
         nargs='+',
         help='Rules to apply for compatibility detection. (default: %(default)s)',
         default=rules,
+        choices=rules,
+    )
+    mutex_group.add_argument(
+        '-b', '--blacklist-rules',
+        nargs='+',
+        help='Rules to ignore for compatibility detection. (default: %(default)s)',
+        default=[],
         choices=rules,
     )
 
@@ -49,7 +56,7 @@ def parser():
     for add_sub_command_parser, associated_function in iteritems(_SUB_COMMAND_ASSOCIATED_FUNCTION_MAPPING):
         add_sub_command_parser(subparsers).set_defaults(func=associated_function)
 
-    if not RuleRegistry.rule_names():
+    if not rules:
         raise parser.error('No rules are defined.')
 
     return parser

--- a/swagger_spec_compatibility/cli/common.py
+++ b/swagger_spec_compatibility/cli/common.py
@@ -27,6 +27,7 @@ class CLIProtocol(typing_extensions.Protocol):
 
 class CLIRulesProtocol(typing_extensions.Protocol):
     rules = None  # type: typing.Iterable[typing.Text]
+    blacklist_rules = None  # type: typing.Iterable[typing.Text]
 
 
 def uri(param):
@@ -48,4 +49,10 @@ def cli_rules():
 
 def rules(cli_args):
     # type: (CLIRulesProtocol) -> typing.Set[typing.Type[BaseRule]]
-    return {RuleRegistry.rule(rule_name) for rule_name in cli_args.rules}
+    return {
+        RuleRegistry.rule(rule_name)
+        for rule_name in cli_args.rules
+        # The parser defines rules and blacklist_rules as mutual exclusive
+        # so we're guaranteed to have at least one set to it's default value
+        if rule_name not in cli_args.blacklist_rules
+    }

--- a/swagger_spec_compatibility/cli/explain.py
+++ b/swagger_spec_compatibility/cli/explain.py
@@ -13,6 +13,7 @@ from swagger_spec_compatibility.cli.common import rules
 
 
 class _Namespace(CLIProtocol):
+    blacklist_rules = None  # type: typing.Iterable[typing.Text]
     rules = None  # type: typing.Iterable[typing.Text]
 
 

--- a/swagger_spec_compatibility/cli/run.py
+++ b/swagger_spec_compatibility/cli/run.py
@@ -22,6 +22,7 @@ from swagger_spec_compatibility.spec_utils import load_spec_from_uri
 
 
 class _Namespace(CLIProtocol):
+    blacklist_rules = None  # type: typing.Iterable[typing.Text]
     rules = None  # type: typing.Iterable[typing.Text]
     strict = None  # type: bool
     json_output = None  # type: bool

--- a/tests/cli/common_test.py
+++ b/tests/cli/common_test.py
@@ -46,10 +46,19 @@ def test_uri_raises_if_path_does_not_exists(tmpdir):
         uri(os.path.join(tmpdir.strpath, str('not-existing-file')))
 
 
-def test_rules(mock_RuleRegistry):
+@pytest.mark.parametrize(
+    'cli_rules, cli_blacklist_rules, expected_rules',
+    [
+        [('DummyRule',), (), {DummyRule}],
+        [('DummyRule',), ('DummyRule',), set()],
+        [(), ('DummyRule',), set()],
+    ],
+)
+def test_rules(mock_RuleRegistry, cli_rules, cli_blacklist_rules, expected_rules):
     assert rules(
         mock.Mock(
             spec=CLIRulesProtocol,
-            rules=('DummyRule',),
+            rules=cli_rules,
+            blacklist_rules=cli_blacklist_rules,
         ),
-    ) == {DummyRule}
+    ) == expected_rules

--- a/tests/cli/run_test.py
+++ b/tests/cli/run_test.py
@@ -23,6 +23,7 @@ def cli_args():
         command='execute',
         func=execute,
         rules=('DummyRule',),
+        blacklist_rules=(),
         strict=False,
         old_spec='memory://',
         new_spec='memory://',


### PR DESCRIPTION
Fixes: #5

The goal of this PR is to add support for blacklisting rules via CLI parameters.
In order to achieve it we're using mutually exclusive CLI arguments, such that it would not be possible to have whitelist and blacklist defined at the same time.
