### PR TITLE
Fix swagger aware walker

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,6 @@ repos:
   - id: debug-statements
   - id: double-quote-string-fixer
   - id: name-tests-test
-  - id: flake8
   - id: check-added-large-files
   - id: check-byte-order-marker
   - id: requirements-txt-fixer
@@ -20,22 +19,27 @@ repos:
   rev: v1.4.3
   hooks:
   - id: autopep8
+- repo: https://gitlab.com/pycqa/flake8.git
+  rev: 3.7.7
+  hooks:
+  - id: flake8
+    exclude: ^docs
 - repo: https://github.com/asottile/reorder_python_imports
-  rev: v1.3.5
+  rev: v1.4.0
   hooks:
   - id: reorder-python-imports
     args: [--add-import, from __future__ import absolute_import, --add-import, from __future__ import unicode_literals, --add-import, from __future__ import print_function]
     exclude: ^setup\.py$
 - repo: https://github.com/asottile/pyupgrade
-  rev: v1.11.2
+  rev: v1.12.0
   hooks:
   - id: pyupgrade
 - repo: https://github.com/asottile/add-trailing-comma
-  rev: v0.7.2
+  rev: v0.8.0
   hooks:
   - id: add-trailing-comma
 - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-  rev: v1.2.2
+  rev: v1.2.3
   hooks:
   - id: pretty-format-yaml
     args: [--autofix, --indent, '2']
@@ -49,4 +53,5 @@ repos:
   hooks:
   - id: mypy
     language_version: python3.6
+    require_serial: true
     exclude: ^docs/.*\.py$

--- a/README.rst
+++ b/README.rst
@@ -154,7 +154,7 @@ Use the following steps to define a new rule:
 
 .. code-block:: python
 
-    from swagger_spec_compatibility.rules.FILE import RuleClassName  # noqa: F401
+    from swagger_spec_compatibility.rules.FILE import RuleClassName
 
 3. Add tests to ensure that your rule behaves as expected (tests in ``tests/rules/FILE_test.py``)
 

--- a/integration_tests/integration_tests_from_test_spec_dir_test.py
+++ b/integration_tests/integration_tests_from_test_spec_dir_test.py
@@ -65,9 +65,14 @@ def test_spec_from_test_specs_directory(test_specification):
         old_spec=load_spec_from_uri(test_specification.old_spec_uri),
         new_spec=load_spec_from_uri(test_specification.new_spec_uri),
     )
-    number_of_reports = len([
+    reports = [
         report
         for reports in itervalues(result)
         for report in reports
-    ])
-    assert number_of_reports == test_specification.number_of_reports
+    ]
+    assert len(reports) == test_specification.number_of_reports, \
+        '{} reports were expected but {} reports received\n{}'.format(
+            test_specification.number_of_reports,
+            len(reports),
+            '\n'.join(report.string_representation() for report in reports)
+        )

--- a/integration_tests/integration_tests_from_test_spec_dir_test.py
+++ b/integration_tests/integration_tests_from_test_spec_dir_test.py
@@ -6,8 +6,8 @@ from __future__ import unicode_literals
 import glob
 import os
 import re
-from typing import Any  # noqa: F401
-from typing import Generator  # noqa: F401
+from typing import Any
+from typing import Generator
 from typing import NamedTuple
 from typing import Text
 
@@ -70,9 +70,9 @@ def test_spec_from_test_specs_directory(test_specification):
         for reports in itervalues(result)
         for report in reports
     ]
-    assert len(reports) == test_specification.number_of_reports, \
-        '{} reports were expected but {} reports received\n{}'.format(
-            test_specification.number_of_reports,
-            len(reports),
-            '\n'.join(report.string_representation() for report in reports),
-        )
+    error_message = '{} reports were expected but {} reports received\n{}'.format(
+        test_specification.number_of_reports,
+        len(reports),
+        '\n'.join(report.string_representation() for report in reports),
+    )
+    assert len(reports) == test_specification.number_of_reports, error_message

--- a/integration_tests/integration_tests_from_test_spec_dir_test.py
+++ b/integration_tests/integration_tests_from_test_spec_dir_test.py
@@ -74,5 +74,5 @@ def test_spec_from_test_specs_directory(test_specification):
         '{} reports were expected but {} reports received\n{}'.format(
             test_specification.number_of_reports,
             len(reports),
-            '\n'.join(report.string_representation() for report in reports)
+            '\n'.join(report.string_representation() for report in reports),
         )

--- a/integration_tests/test-specs/case-003-0-reports-remove-parameter/new.yaml
+++ b/integration_tests/test-specs/case-003-0-reports-remove-parameter/new.yaml
@@ -1,0 +1,14 @@
+swagger: '2.0'
+info:
+  title: Test
+  version: '1.0'
+paths:
+  /endpoint:
+    get:
+      parameters:
+      - in: query
+        name: param2
+        type: integer
+      responses:
+        default:
+          description: ''

--- a/integration_tests/test-specs/case-003-0-reports-remove-parameter/old.yaml
+++ b/integration_tests/test-specs/case-003-0-reports-remove-parameter/old.yaml
@@ -1,0 +1,17 @@
+swagger: '2.0'
+info:
+  title: Test
+  version: '1.0'
+paths:
+  /endpoint:
+    get:
+      parameters:
+      - in: query
+        name: param1
+        type: string
+      - in: query
+        name: param2
+        type: integer
+      responses:
+        default:
+          description: ''

--- a/integration_tests/test-specs/case-004-1-reports-change-definition-type/new.yaml
+++ b/integration_tests/test-specs/case-004-1-reports-change-definition-type/new.yaml
@@ -1,0 +1,17 @@
+swagger: '2.0'
+info:
+  title: Test
+  version: '1.0'
+definitions:
+  model:
+    properties:
+      property1:
+        type: string
+paths:
+  /endpoint:
+    get:
+      responses:
+        default:
+          description: ''
+          schema:
+            $ref: '#/definitions/model'

--- a/integration_tests/test-specs/case-004-1-reports-change-definition-type/old.yaml
+++ b/integration_tests/test-specs/case-004-1-reports-change-definition-type/old.yaml
@@ -1,0 +1,17 @@
+swagger: '2.0'
+info:
+  title: Test
+  version: '1.0'
+definitions:
+  model:
+    properties:
+      property1:
+        type: boolean
+paths:
+  /endpoint:
+    get:
+      responses:
+        default:
+          description: ''
+          schema:
+            $ref: '#/definitions/model'

--- a/swagger_spec_compatibility/__main__.py
+++ b/swagger_spec_compatibility/__main__.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import typing  # noqa: F401
+import typing
 
 from swagger_spec_compatibility.cli import parser
 

--- a/swagger_spec_compatibility/cli/__init__.py
+++ b/swagger_spec_compatibility/cli/__init__.py
@@ -8,8 +8,8 @@ from textwrap import dedent
 
 from six import iteritems
 
-from swagger_spec_compatibility.cli import explain  # noqa: F401
-from swagger_spec_compatibility.cli import run  # noqa: F401
+from swagger_spec_compatibility.cli import explain
+from swagger_spec_compatibility.cli import run
 from swagger_spec_compatibility.cli.common import cli_rules
 from swagger_spec_compatibility.rules import RuleRegistry
 from swagger_spec_compatibility.util import wrap

--- a/swagger_spec_compatibility/cli/common.py
+++ b/swagger_spec_compatibility/cli/common.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import typing  # noqa: F401
+import typing
 from argparse import ArgumentTypeError
 from os.path import abspath
 from os.path import exists
@@ -16,8 +16,8 @@ from six.moves.urllib.parse import urlsplit
 from six.moves.urllib.request import pathname2url
 from six.moves.urllib.request import url2pathname
 
-from swagger_spec_compatibility.rules.common import BaseRule  # noqa: F401
-from swagger_spec_compatibility.rules.common import RuleRegistry  # noqa: F401
+from swagger_spec_compatibility.rules.common import BaseRule
+from swagger_spec_compatibility.rules.common import RuleRegistry
 
 
 class CLIProtocol(typing_extensions.Protocol):

--- a/swagger_spec_compatibility/cli/explain.py
+++ b/swagger_spec_compatibility/cli/explain.py
@@ -3,8 +3,8 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import argparse  # noqa: F401
-import typing  # noqa: F401
+import argparse
+import typing
 
 from termcolor import colored
 

--- a/swagger_spec_compatibility/cli/run.py
+++ b/swagger_spec_compatibility/cli/run.py
@@ -3,10 +3,10 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import argparse  # noqa: F401
+import argparse
 import json
 import sys
-import typing  # noqa: F401
+import typing
 
 from six import iteritems
 
@@ -14,10 +14,9 @@ from swagger_spec_compatibility.cli.common import CLIProtocol
 from swagger_spec_compatibility.cli.common import rules
 from swagger_spec_compatibility.cli.common import uri
 from swagger_spec_compatibility.rules import compatibility_status
-from swagger_spec_compatibility.rules import ValidationMessage  # noqa: F401
-from swagger_spec_compatibility.rules.common import BaseRule  # noqa: F401
+from swagger_spec_compatibility.rules import ValidationMessage
 from swagger_spec_compatibility.rules.common import Level
-from swagger_spec_compatibility.rules.common import RuleProtocol  # noqa: F401
+from swagger_spec_compatibility.rules.common import RuleProtocol
 from swagger_spec_compatibility.spec_utils import load_spec_from_uri
 
 

--- a/swagger_spec_compatibility/rules/__init__.py
+++ b/swagger_spec_compatibility/rules/__init__.py
@@ -3,17 +3,17 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import typing  # noqa: F401
+import typing
 
-from bravado_core.spec import Spec  # noqa: F401
+from bravado_core.spec import Spec
 
 from swagger_spec_compatibility.rules.added_enum_value_in_response import AddedEnumValueInRequest  # noqa: F401
 from swagger_spec_compatibility.rules.added_properties_in_response_objects_with_additional_properties_set_to_false import AddedPropertiesInResponseObjectsWithAdditionalPropertiesSetToFalse  # noqa: F401,E501
 from swagger_spec_compatibility.rules.added_required_property_in_request import AddedRequiredPropertyInRequest  # noqa: F401
 from swagger_spec_compatibility.rules.changed_type import ChangedType  # noqa: F401
-from swagger_spec_compatibility.rules.common import RuleProtocol  # noqa: F401
-from swagger_spec_compatibility.rules.common import RuleRegistry  # noqa: F401
-from swagger_spec_compatibility.rules.common import ValidationMessage  # noqa: F401
+from swagger_spec_compatibility.rules.common import RuleProtocol
+from swagger_spec_compatibility.rules.common import RuleRegistry
+from swagger_spec_compatibility.rules.common import ValidationMessage
 from swagger_spec_compatibility.rules.deleted_endpoint import DeletedEndpoint  # noqa: F401
 from swagger_spec_compatibility.rules.removed_enum_value_from_request import RemovedEnumValueFromRequest  # noqa: F401
 from swagger_spec_compatibility.rules.removed_properties_from_request_objects_with_additional_properties_set_to_false import RemovedPropertiesFromRequestObjectsWithAdditionalPropertiesSetToFalse  # noqa: F401,E501

--- a/swagger_spec_compatibility/rules/added_enum_value_in_response.py
+++ b/swagger_spec_compatibility/rules/added_enum_value_in_response.py
@@ -3,16 +3,16 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import typing  # noqa: F401
+import typing
 
-from bravado_core.spec import Spec  # noqa: F401
+from bravado_core.spec import Spec
 
 from swagger_spec_compatibility.rules.common import BaseRule
 from swagger_spec_compatibility.rules.common import Level
 from swagger_spec_compatibility.rules.common import RuleType
-from swagger_spec_compatibility.rules.common import ValidationMessage  # noqa: F401
+from swagger_spec_compatibility.rules.common import ValidationMessage
 from swagger_spec_compatibility.util import is_path_in_top_level_paths
-from swagger_spec_compatibility.walkers import format_path  # noqa: F401
+from swagger_spec_compatibility.walkers import format_path
 from swagger_spec_compatibility.walkers.enum_values import EnumValuesDifferWalker
 from swagger_spec_compatibility.walkers.response_paths import ResponsePathsWalker
 

--- a/swagger_spec_compatibility/rules/added_properties_in_response_objects_with_additional_properties_set_to_false.py
+++ b/swagger_spec_compatibility/rules/added_properties_in_response_objects_with_additional_properties_set_to_false.py
@@ -3,14 +3,14 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import typing  # noqa: F401
+import typing
 
-from bravado_core.spec import Spec  # noqa: F401
+from bravado_core.spec import Spec
 
 from swagger_spec_compatibility.rules.common import BaseRule
 from swagger_spec_compatibility.rules.common import Level
 from swagger_spec_compatibility.rules.common import RuleType
-from swagger_spec_compatibility.rules.common import ValidationMessage  # noqa: F401
+from swagger_spec_compatibility.rules.common import ValidationMessage
 from swagger_spec_compatibility.util import is_path_in_top_level_paths
 from swagger_spec_compatibility.walkers import format_path
 from swagger_spec_compatibility.walkers.additional_properties import AdditionalPropertiesDifferWalker

--- a/swagger_spec_compatibility/rules/added_required_property_in_request.py
+++ b/swagger_spec_compatibility/rules/added_required_property_in_request.py
@@ -3,16 +3,16 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import typing  # noqa: F401
+import typing
 
-from bravado_core.spec import Spec  # noqa: F401
+from bravado_core.spec import Spec
 
 from swagger_spec_compatibility.rules.common import BaseRule
 from swagger_spec_compatibility.rules.common import Level
 from swagger_spec_compatibility.rules.common import RuleType
-from swagger_spec_compatibility.rules.common import ValidationMessage  # noqa: F401
+from swagger_spec_compatibility.rules.common import ValidationMessage
 from swagger_spec_compatibility.util import is_path_in_top_level_paths
-from swagger_spec_compatibility.walkers import format_path  # noqa: F401
+from swagger_spec_compatibility.walkers import format_path
 from swagger_spec_compatibility.walkers.request_parameters import RequestParametersWalker
 from swagger_spec_compatibility.walkers.required_properties import RequiredPropertiesDifferWalker
 

--- a/swagger_spec_compatibility/rules/changed_type.py
+++ b/swagger_spec_compatibility/rules/changed_type.py
@@ -3,14 +3,14 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import typing  # noqa: F401
+import typing
 
-from bravado_core.spec import Spec  # noqa: F401
+from bravado_core.spec import Spec
 
 from swagger_spec_compatibility.rules.common import BaseRule
 from swagger_spec_compatibility.rules.common import Level
 from swagger_spec_compatibility.rules.common import RuleType
-from swagger_spec_compatibility.rules.common import ValidationMessage   # noqa: F401
+from swagger_spec_compatibility.rules.common import ValidationMessage
 from swagger_spec_compatibility.util import is_path_in_top_level_paths
 from swagger_spec_compatibility.walkers import format_path
 from swagger_spec_compatibility.walkers.changed_types import ChangedTypesDifferWalker

--- a/swagger_spec_compatibility/rules/common.py
+++ b/swagger_spec_compatibility/rules/common.py
@@ -9,7 +9,7 @@ from abc import abstractmethod
 from enum import IntEnum
 
 import typing_extensions
-from bravado_core.spec import Spec  # noqa: F401
+from bravado_core.spec import Spec
 from six import iterkeys
 from six import itervalues
 from six import with_metaclass

--- a/swagger_spec_compatibility/rules/deleted_endpoint.py
+++ b/swagger_spec_compatibility/rules/deleted_endpoint.py
@@ -3,14 +3,14 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import typing  # noqa: F401
+import typing
 
-from bravado_core.spec import Spec  # noqa: F401
+from bravado_core.spec import Spec
 
 from swagger_spec_compatibility.rules.common import BaseRule
 from swagger_spec_compatibility.rules.common import Level
 from swagger_spec_compatibility.rules.common import RuleType
-from swagger_spec_compatibility.rules.common import ValidationMessage   # noqa: F401
+from swagger_spec_compatibility.rules.common import ValidationMessage
 from swagger_spec_compatibility.spec_utils import get_endpoints
 
 

--- a/swagger_spec_compatibility/rules/removed_enum_value_from_request.py
+++ b/swagger_spec_compatibility/rules/removed_enum_value_from_request.py
@@ -3,16 +3,16 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import typing  # noqa: F401
+import typing
 
-from bravado_core.spec import Spec  # noqa: F401
+from bravado_core.spec import Spec
 
 from swagger_spec_compatibility.rules.common import BaseRule
 from swagger_spec_compatibility.rules.common import Level
 from swagger_spec_compatibility.rules.common import RuleType
-from swagger_spec_compatibility.rules.common import ValidationMessage  # noqa: F401
+from swagger_spec_compatibility.rules.common import ValidationMessage
 from swagger_spec_compatibility.util import is_path_in_top_level_paths
-from swagger_spec_compatibility.walkers import format_path  # noqa: F401
+from swagger_spec_compatibility.walkers import format_path
 from swagger_spec_compatibility.walkers.enum_values import EnumValuesDifferWalker
 from swagger_spec_compatibility.walkers.request_parameters import RequestParametersWalker
 

--- a/swagger_spec_compatibility/rules/removed_properties_from_request_objects_with_additional_properties_set_to_false.py
+++ b/swagger_spec_compatibility/rules/removed_properties_from_request_objects_with_additional_properties_set_to_false.py
@@ -3,14 +3,14 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import typing  # noqa: F401
+import typing
 
-from bravado_core.spec import Spec  # noqa: F401
+from bravado_core.spec import Spec
 
 from swagger_spec_compatibility.rules.common import BaseRule
 from swagger_spec_compatibility.rules.common import Level
 from swagger_spec_compatibility.rules.common import RuleType
-from swagger_spec_compatibility.rules.common import ValidationMessage  # noqa: F401
+from swagger_spec_compatibility.rules.common import ValidationMessage
 from swagger_spec_compatibility.util import is_path_in_top_level_paths
 from swagger_spec_compatibility.walkers import format_path
 from swagger_spec_compatibility.walkers.additional_properties import AdditionalPropertiesDifferWalker

--- a/swagger_spec_compatibility/rules/removed_required_property_from_response.py
+++ b/swagger_spec_compatibility/rules/removed_required_property_from_response.py
@@ -3,14 +3,14 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import typing  # noqa: F401
+import typing
 
-from bravado_core.spec import Spec  # noqa: F401
+from bravado_core.spec import Spec
 
 from swagger_spec_compatibility.rules.common import BaseRule
 from swagger_spec_compatibility.rules.common import Level
 from swagger_spec_compatibility.rules.common import RuleType
-from swagger_spec_compatibility.rules.common import ValidationMessage  # noqa: F401
+from swagger_spec_compatibility.rules.common import ValidationMessage
 from swagger_spec_compatibility.util import is_path_in_top_level_paths
 from swagger_spec_compatibility.walkers import format_path
 from swagger_spec_compatibility.walkers.required_properties import RequiredPropertiesDifferWalker

--- a/swagger_spec_compatibility/spec_utils.py
+++ b/swagger_spec_compatibility/spec_utils.py
@@ -8,8 +8,8 @@ from enum import Enum
 from itertools import chain
 
 from bravado.client import SwaggerClient
-from bravado_core.operation import Operation  # noqa: F401
-from bravado_core.spec import Spec  # noqa: F401
+from bravado_core.operation import Operation
+from bravado_core.spec import Spec
 from bravado_core.util import determine_object_type
 from bravado_core.util import ObjectType
 from six import iterkeys

--- a/swagger_spec_compatibility/util.py
+++ b/swagger_spec_compatibility/util.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import typing
-from functools import total_ordering
 from textwrap import TextWrapper
 
 from swagger_spec_compatibility.walkers import PathType
@@ -25,7 +24,6 @@ def wrap(text, width=120, indent=''):
     return '\n'.join('\n'.join(wrapper.wrap(line)) for line in text.splitlines())
 
 
-@total_ordering
 class EntityMapping(typing.Generic[T]):
     __slots__ = ('_old', '_new')
 
@@ -63,10 +61,6 @@ class EntityMapping(typing.Generic[T]):
             self.__class__.__name__, self.old,
             self.new,
         ))  # pragma: no cover  # This statement is present only to have a nicer REPL experience # noqa
-
-    def __lt__(self, other):
-        # type: (typing.Any) -> bool
-        return isinstance(other, self.__class__) and (self._old, self._new) < (other._old, other._new)
 
 
 def is_path_in_top_level_paths(top_level_paths, path):

--- a/swagger_spec_compatibility/util.py
+++ b/swagger_spec_compatibility/util.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import typing
+from functools import total_ordering
 from textwrap import TextWrapper
 
 from swagger_spec_compatibility.walkers import PathType
@@ -24,6 +25,7 @@ def wrap(text, width=120, indent=''):
     return '\n'.join('\n'.join(wrapper.wrap(line)) for line in text.splitlines())
 
 
+@total_ordering
 class EntityMapping(typing.Generic[T]):
     __slots__ = ('_old', '_new')
 
@@ -61,6 +63,10 @@ class EntityMapping(typing.Generic[T]):
             self.__class__.__name__, self.old,
             self.new,
         ))  # pragma: no cover  # This statement is present only to have a nicer REPL experience # noqa
+
+    def __lt__(self, other):
+        # type: (typing.Any) -> bool
+        return isinstance(other, self.__class__) and (self._old, self._new) < (other._old, other._new)
 
 
 def is_path_in_top_level_paths(top_level_paths, path):

--- a/swagger_spec_compatibility/util.py
+++ b/swagger_spec_compatibility/util.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 import typing
 from textwrap import TextWrapper
 
-from swagger_spec_compatibility.walkers import PathType  # noqa: F401
+from swagger_spec_compatibility.walkers import PathType
 
 T = typing.TypeVar('T')
 

--- a/swagger_spec_compatibility/walkers/__init__.py
+++ b/swagger_spec_compatibility/walkers/__init__.py
@@ -167,7 +167,7 @@ class Walker(typing.Generic[T]):
         NOTE:   the traversing is internally cached such that all the subsequent calls
                 to `walk()` are equivalent to an attribute access
         """
-        if isinstance(self._walk_result, NoValue):
+        if isinstance(self._walk_result, NoValue):  # pragma: no branch
             self._walk_result = list(self._inner_walk(
                 path=tuple(),
                 left=self.left,
@@ -218,15 +218,15 @@ class SchemaWalker(Walker[T]):
 
     def _get_original_parameter_path(self, path, parameters_index):
         # type: (PathType, typing.Mapping[typing.Text, int]) -> PathType
-        if isinstance(path[-1], int):
-            # Weird that we got up to this point, this should never happen
+        try:
+            # Ignoring type as path[-1] could be an integer which is not expected for parameters_index
+            # it's not really a big deal as it should not happen and if this happens then KeyError will be thrown
+            return tuple(chain(path[:-1], [parameters_index[path[-1]]]))  # type: ignore
+        except KeyError:
+            # This could happen only if the parameter was present only on the old specs
+            # or if the path was actually not "modified" by the walker (NOTE: the later condition should not be possible)
             # but let's do it so mypy is happy too
             return path
-        else:
-            try:
-                return tuple(chain(path[:-1], [parameters_index[path[-1]]]))
-            except AttributeError:
-                return path
 
     def fix_parameter_path(self, path, original_path, value):
         # type: (PathType, PathType, T) -> T

--- a/swagger_spec_compatibility/walkers/__init__.py
+++ b/swagger_spec_compatibility/walkers/__init__.py
@@ -8,7 +8,7 @@ from abc import abstractmethod
 from collections import defaultdict
 from itertools import chain
 
-from bravado_core.spec import Spec  # noqa: F401
+from bravado_core.spec import Spec
 from six import iteritems
 from six import iterkeys
 from six import text_type

--- a/swagger_spec_compatibility/walkers/additional_properties.py
+++ b/swagger_spec_compatibility/walkers/additional_properties.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 
 import typing
 from enum import Enum
+from itertools import chain
 
 from bravado_core.spec import Spec
 
@@ -20,14 +21,22 @@ class DiffType(Enum):
     VALUE = 1
 
 
-AdditionalPropertiesDiff = typing.NamedTuple(
+class AdditionalPropertiesDiff(typing.NamedTuple(
     'AdditionalPropertiesDiff', (
         ('path', PathType),
         ('diff_type', DiffType),
         ('additionalProperties', typing.Optional[EntityMapping[typing.Union[bool, typing.Mapping[typing.Text, typing.Any]]]]),
         ('properties', typing.Optional[EntityMapping[typing.Set[typing.Text]]]),
     ),
-)
+)):
+    def fix_parameter_path(self, path, original_path):
+        # type: (PathType, PathType) -> 'AdditionalPropertiesDiff'
+        return AdditionalPropertiesDiff(
+            path=tuple(chain(original_path, self.path[len(original_path):])),
+            diff_type=self.diff_type,
+            additionalProperties=self.additionalProperties,
+            properties=self.properties,
+        )
 
 
 def _evaluate_additional_properties_diffs(

--- a/swagger_spec_compatibility/walkers/additional_properties.py
+++ b/swagger_spec_compatibility/walkers/additional_properties.py
@@ -10,6 +10,7 @@ from bravado_core.spec import Spec
 
 from swagger_spec_compatibility.spec_utils import get_properties
 from swagger_spec_compatibility.util import EntityMapping
+from swagger_spec_compatibility.walkers import NoValue
 from swagger_spec_compatibility.walkers import PathType
 from swagger_spec_compatibility.walkers import SchemaWalker
 
@@ -20,7 +21,7 @@ class DiffType(Enum):
 
 
 AdditionalPropertiesDiff = typing.NamedTuple(
-    'EnumValuesDiff', (
+    'AdditionalPropertiesDiff', (
         ('path', PathType),
         ('diff_type', DiffType),
         ('additionalProperties', typing.Optional[EntityMapping[typing.Union[bool, typing.Mapping[typing.Text, typing.Any]]]]),
@@ -81,41 +82,30 @@ class AdditionalPropertiesDifferWalker(SchemaWalker[AdditionalPropertiesDiff]):
     additionalPropertiesValue = None  # type: typing.Union[bool, typing.Mapping[typing.Text, typing.Any]]
     diffs = None  # type: typing.List[AdditionalPropertiesDiff]
 
-    def __init__(
-        self,
-        left_spec,  # type: Spec
-        right_spec,  # type: Spec
-    ):
-        # type: (...) -> None
-        super(AdditionalPropertiesDifferWalker, self).__init__(
-            left_spec=left_spec,
-            right_spec=right_spec,
-        )
-        self.diffs = []
-
     def dict_check(
         self,
         path,  # type: PathType
-        left_dict,  # type: typing.Optional[typing.Mapping[typing.Text, typing.Any]]
-        right_dict,  # type: typing.Optional[typing.Mapping[typing.Text, typing.Any]]
+        left_dict,  # type: typing.Union[NoValue, typing.Mapping[typing.Text, typing.Any]]
+        right_dict,  # type: typing.Union[NoValue, typing.Mapping[typing.Text, typing.Any]]
     ):
-        # type: (...) -> None  # noqa
-        self.diffs.extend(_evaluate_additional_properties_diffs(
+        # type: (...) -> typing.Iterable[AdditionalPropertiesDiff]
+
+        return _evaluate_additional_properties_diffs(
             path=path,
             left_spec=self.left_spec,
             right_spec=self.right_spec,
-            left_schema=left_dict,
-            right_schema=right_dict,
-        ))
+            left_schema=None if isinstance(left_dict, NoValue) else left_dict,
+            right_schema=None if isinstance(right_dict, NoValue) else right_dict,
+        )
 
     def list_check(
         self,
         path,  # type: PathType
-        left_list,  # type: typing.Optional[typing.Sequence[typing.Any]]
-        right_list,  # type: typing.Optional[typing.Sequence[typing.Any]]
+        left_list,  # type: typing.Union[NoValue, typing.Sequence[typing.Any]]
+        right_list,  # type: typing.Union[NoValue, typing.Sequence[typing.Any]]
     ):
-        # type: (...) -> None  # noqa
-        pass
+        # type: (...) -> typing.Iterable[AdditionalPropertiesDiff]
+        return ()
 
     def value_check(
         self,
@@ -123,9 +113,5 @@ class AdditionalPropertiesDifferWalker(SchemaWalker[AdditionalPropertiesDiff]):
         left_value,  # type: typing.Any
         right_value,  # type: typing.Any
     ):
-        # type: (...) -> None
-        pass
-
-    def walk_response(self):
-        # type: () -> typing.List[AdditionalPropertiesDiff]
-        return self.diffs
+        # type: (...) -> typing.Iterable[AdditionalPropertiesDiff]
+        return ()

--- a/swagger_spec_compatibility/walkers/additional_properties.py
+++ b/swagger_spec_compatibility/walkers/additional_properties.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 import typing
 from enum import Enum
 
-from bravado_core.spec import Spec  # noqa: F401
+from bravado_core.spec import Spec
 
 from swagger_spec_compatibility.spec_utils import get_properties
 from swagger_spec_compatibility.util import EntityMapping

--- a/swagger_spec_compatibility/walkers/changed_types.py
+++ b/swagger_spec_compatibility/walkers/changed_types.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import typing
+from itertools import chain
 
 from bravado_core.spec import Spec
 
@@ -37,12 +38,18 @@ def _different_types_mapping(
         )
 
 
-ChangedTypesDiff = typing.NamedTuple(
+class ChangedTypesDiff(typing.NamedTuple(
     'ChangedTypesDiff', (
         ('path', PathType),
         ('mapping', EntityMapping[typing.Optional[typing.Text]]),
     ),
-)
+)):
+    def fix_parameter_path(self, path, original_path):
+        # type: (PathType, PathType) -> 'ChangedTypesDiff'
+        return ChangedTypesDiff(
+            path=tuple(chain(original_path, self.path[len(original_path):])),
+            mapping=self.mapping,
+        )
 
 
 class ChangedTypesDifferWalker(SchemaWalker[ChangedTypesDiff]):

--- a/swagger_spec_compatibility/walkers/changed_types.py
+++ b/swagger_spec_compatibility/walkers/changed_types.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 
 import typing
 
-from bravado_core.spec import Spec  # noqa: F401
+from bravado_core.spec import Spec
 
 from swagger_spec_compatibility.util import EntityMapping
 from swagger_spec_compatibility.walkers import PathType

--- a/swagger_spec_compatibility/walkers/changed_types.py
+++ b/swagger_spec_compatibility/walkers/changed_types.py
@@ -8,6 +8,7 @@ import typing
 from bravado_core.spec import Spec
 
 from swagger_spec_compatibility.util import EntityMapping
+from swagger_spec_compatibility.walkers import NoValue
 from swagger_spec_compatibility.walkers import PathType
 from swagger_spec_compatibility.walkers import SchemaWalker
 
@@ -59,35 +60,38 @@ class ChangedTypesDifferWalker(SchemaWalker[ChangedTypesDiff]):
             left_spec=left_spec,
             right_spec=right_spec,
         )
-        self.diffs = []
 
     def dict_check(
         self,
         path,  # type: PathType
-        left_dict,  # type: typing.Optional[typing.Mapping[typing.Text, typing.Any]]
-        right_dict,  # type: typing.Optional[typing.Mapping[typing.Text, typing.Any]]
+        left_dict,  # type: typing.Union[NoValue, typing.Mapping[typing.Text, typing.Any]]
+        right_dict,  # type: typing.Union[NoValue, typing.Mapping[typing.Text, typing.Any]]
     ):
-        # type: (...) -> None  # noqa
+        # type: (...) -> typing.Iterable[ChangedTypesDiff]
         different_types_mapping = _different_types_mapping(
             left_spec=self.left_spec,
             right_spec=self.right_spec,
-            left_schema=left_dict,
-            right_schema=right_dict,
+            left_schema=None if isinstance(left_dict, NoValue) else left_dict,
+            right_schema=None if isinstance(right_dict, NoValue) else right_dict,
         )
         if different_types_mapping:
-            self.diffs.append(ChangedTypesDiff(
-                path=path,
-                mapping=different_types_mapping,
-            ))
+            return (
+                ChangedTypesDiff(
+                    path=path,
+                    mapping=different_types_mapping,
+                ),
+            )
+        else:
+            return ()
 
     def list_check(
         self,
         path,  # type: PathType
-        left_list,  # type: typing.Optional[typing.Sequence[typing.Any]]
-        right_list,  # type: typing.Optional[typing.Sequence[typing.Any]]
+        left_list,  # type: typing.Union[NoValue, typing.Sequence[typing.Any]]
+        right_list,  # type: typing.Union[NoValue, typing.Sequence[typing.Any]]
     ):
-        # type: (...) -> None  # noqa
-        pass
+        # type: (...) -> typing.Iterable[ChangedTypesDiff]
+        return ()
 
     def value_check(
         self,
@@ -95,9 +99,5 @@ class ChangedTypesDifferWalker(SchemaWalker[ChangedTypesDiff]):
         left_value,  # type: typing.Any
         right_value,  # type: typing.Any
     ):
-        # type: (...) -> None
-        pass
-
-    def walk_response(self):
-        # type: () -> typing.List[ChangedTypesDiff]
-        return self.diffs
+        # type: (...) -> typing.Iterable[ChangedTypesDiff]
+        return ()

--- a/swagger_spec_compatibility/walkers/enum_values.py
+++ b/swagger_spec_compatibility/walkers/enum_values.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import typing
+from itertools import chain
 
 from bravado_core.spec import Spec
 
@@ -42,29 +43,23 @@ def _different_enum_values_mapping(
         )
 
 
-EnumValuesDiff = typing.NamedTuple(
+class EnumValuesDiff(typing.NamedTuple(
     'EnumValuesDiff', (
         ('path', PathType),
         ('mapping', EntityMapping[typing.Any]),
     ),
-)
+)):
+    def fix_parameter_path(self, path, original_path):
+        # type: (PathType, PathType) -> 'EnumValuesDiff'
+        return EnumValuesDiff(
+            path=tuple(chain(original_path, self.path[len(original_path):])),
+            mapping=self.mapping,
+        )
 
 
 class EnumValuesDifferWalker(SchemaWalker[EnumValuesDiff]):
     left_spec = None  # type: Spec
     right_spec = None  # type: Spec
-    diffs = None  # type: typing.List[EnumValuesDiff]
-
-    def __init__(
-        self,
-        left_spec,  # type: Spec
-        right_spec,  # type: Spec
-    ):
-        # type: (...) -> None
-        super(EnumValuesDifferWalker, self).__init__(
-            left_spec=left_spec,
-            right_spec=right_spec,
-        )
 
     def dict_check(
         self,

--- a/swagger_spec_compatibility/walkers/enum_values.py
+++ b/swagger_spec_compatibility/walkers/enum_values.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 
 import typing
 
-from bravado_core.spec import Spec  # noqa: F401
+from bravado_core.spec import Spec
 
 from swagger_spec_compatibility.util import EntityMapping
 from swagger_spec_compatibility.walkers import PathType

--- a/swagger_spec_compatibility/walkers/enum_values.py
+++ b/swagger_spec_compatibility/walkers/enum_values.py
@@ -8,6 +8,7 @@ import typing
 from bravado_core.spec import Spec
 
 from swagger_spec_compatibility.util import EntityMapping
+from swagger_spec_compatibility.walkers import NoValue
 from swagger_spec_compatibility.walkers import PathType
 from swagger_spec_compatibility.walkers import SchemaWalker
 
@@ -64,35 +65,38 @@ class EnumValuesDifferWalker(SchemaWalker[EnumValuesDiff]):
             left_spec=left_spec,
             right_spec=right_spec,
         )
-        self.diffs = []
 
     def dict_check(
         self,
         path,  # type: PathType
-        left_dict,  # type: typing.Optional[typing.Mapping[typing.Text, typing.Any]]
-        right_dict,  # type: typing.Optional[typing.Mapping[typing.Text, typing.Any]]
+        left_dict,  # type: typing.Union[NoValue, typing.Mapping[typing.Text, typing.Any]]
+        right_dict,  # type: typing.Union[NoValue, typing.Mapping[typing.Text, typing.Any]]
     ):
-        # type: (...) -> None  # noqa
+        # type: (...) -> typing.Iterable[EnumValuesDiff]
         different_enum_values_mapping = _different_enum_values_mapping(
             left_spec=self.left_spec,
             right_spec=self.right_spec,
-            left_schema=left_dict,
-            right_schema=right_dict,
+            left_schema=None if isinstance(left_dict, NoValue) else left_dict,
+            right_schema=None if isinstance(right_dict, NoValue) else right_dict,
         )
         if different_enum_values_mapping is not None:
-            self.diffs.append(EnumValuesDiff(
-                path=path,
-                mapping=different_enum_values_mapping,
-            ))
+            return (
+                EnumValuesDiff(
+                    path=path,
+                    mapping=different_enum_values_mapping,
+                ),
+            )
+        else:
+            return ()
 
     def list_check(
         self,
         path,  # type: PathType
-        left_list,  # type: typing.Optional[typing.Sequence[typing.Any]]
-        right_list,  # type: typing.Optional[typing.Sequence[typing.Any]]
+        left_list,  # type: typing.Union[NoValue, typing.Sequence[typing.Any]]
+        right_list,  # type: typing.Union[NoValue, typing.Sequence[typing.Any]]
     ):
-        # type: (...) -> None  # noqa
-        pass
+        # type: (...) -> typing.Iterable[EnumValuesDiff]
+        return ()
 
     def value_check(
         self,
@@ -100,9 +104,5 @@ class EnumValuesDifferWalker(SchemaWalker[EnumValuesDiff]):
         left_value,  # type: typing.Any
         right_value,  # type: typing.Any
     ):
-        # type: (...) -> None
-        pass
-
-    def walk_response(self):
-        # type: () -> typing.List[EnumValuesDiff]
-        return self.diffs
+        # type: (...) -> typing.Iterable[EnumValuesDiff]
+        return ()

--- a/swagger_spec_compatibility/walkers/request_parameters.py
+++ b/swagger_spec_compatibility/walkers/request_parameters.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import typing
+from itertools import chain
 
 from bravado_core.spec import Spec
 from bravado_core.util import determine_object_type
@@ -18,7 +19,10 @@ class RequestParametersWalker(SchemaWalker[PathType]):
     # TODO: update the name as it gets only the schemas of the parameters
     left_spec = None  # type: Spec
     right_spec = None  # type: Spec
-    paths = None  # type: typing.Set[PathType]
+
+    def fix_parameter_path(self, path, original_path, value):
+        # type: (PathType, PathType, PathType) -> PathType
+        return tuple(chain(original_path, value[len(original_path):]))
 
     def should_path_be_walked_through(self, path):
         # type: (PathType) -> bool
@@ -46,11 +50,6 @@ class RequestParametersWalker(SchemaWalker[PathType]):
     ):
         # type: (...) -> None
         super(RequestParametersWalker, self).__init__(left_spec=left_spec, right_spec=right_spec)
-        self.paths = set()
-
-    def walk_response(self):
-        # type: () -> typing.Iterable[PathType]
-        return self.paths
 
     def dict_check(
         self,

--- a/swagger_spec_compatibility/walkers/request_parameters.py
+++ b/swagger_spec_compatibility/walkers/request_parameters.py
@@ -9,6 +9,7 @@ from bravado_core.spec import Spec
 from bravado_core.util import determine_object_type
 from bravado_core.util import ObjectType
 
+from swagger_spec_compatibility.walkers import NoValue
 from swagger_spec_compatibility.walkers import PathType
 from swagger_spec_compatibility.walkers import SchemaWalker
 
@@ -54,21 +55,23 @@ class RequestParametersWalker(SchemaWalker[PathType]):
     def dict_check(
         self,
         path,  # type: PathType
-        left_dict,  # type: typing.Optional[typing.Mapping[typing.Text, typing.Any]]
-        right_dict,  # type: typing.Optional[typing.Mapping[typing.Text, typing.Any]]
+        left_dict,  # type: typing.Union[NoValue, typing.Mapping[typing.Text, typing.Any]]
+        right_dict,  # type: typing.Union[NoValue, typing.Mapping[typing.Text, typing.Any]]
     ):
-        # type: (...) -> None  # noqa
+        # type: (...) -> typing.Iterable[PathType]
         if determine_object_type(left_dict) == ObjectType.PARAMETER or determine_object_type(right_dict) == ObjectType.PARAMETER:
-            self.paths.add(path)
+            return (path, )
+        else:
+            return ()
 
     def list_check(
         self,
         path,  # type: PathType
-        left_list,  # type: typing.Optional[typing.Sequence[typing.Any]]
-        right_list,  # type: typing.Optional[typing.Sequence[typing.Any]]
+        left_list,  # type: typing.Union[NoValue, typing.Sequence[typing.Any]]
+        right_list,  # type: typing.Union[NoValue, typing.Sequence[typing.Any]]
     ):
-        # type: (...) -> None  # noqa
-        pass
+        # type: (...) -> typing.Iterable[PathType]
+        return ()
 
     def value_check(
         self,
@@ -76,5 +79,5 @@ class RequestParametersWalker(SchemaWalker[PathType]):
         left_value,  # type: typing.Any
         right_value,  # type: typing.Any
     ):
-        # type: (...) -> None  # noqa
-        pass
+        # type: (...) -> typing.Iterable[PathType]
+        return ()

--- a/swagger_spec_compatibility/walkers/request_parameters.py
+++ b/swagger_spec_compatibility/walkers/request_parameters.py
@@ -3,9 +3,9 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import typing  # noqa: F401
+import typing
 
-from bravado_core.spec import Spec  # noqa: F401
+from bravado_core.spec import Spec
 from bravado_core.util import determine_object_type
 from bravado_core.util import ObjectType
 

--- a/swagger_spec_compatibility/walkers/required_properties.py
+++ b/swagger_spec_compatibility/walkers/required_properties.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 
 import typing
 
-from bravado_core.spec import Spec  # noqa: F401
+from bravado_core.spec import Spec
 
 from swagger_spec_compatibility.spec_utils import get_required_properties
 from swagger_spec_compatibility.util import EntityMapping

--- a/swagger_spec_compatibility/walkers/required_properties.py
+++ b/swagger_spec_compatibility/walkers/required_properties.py
@@ -9,6 +9,7 @@ from bravado_core.spec import Spec
 
 from swagger_spec_compatibility.spec_utils import get_required_properties
 from swagger_spec_compatibility.util import EntityMapping
+from swagger_spec_compatibility.walkers import NoValue
 from swagger_spec_compatibility.walkers import PathType
 from swagger_spec_compatibility.walkers import SchemaWalker
 
@@ -57,35 +58,38 @@ class RequiredPropertiesDifferWalker(SchemaWalker[RequiredPropertiesDiff]):
             left_spec=left_spec,
             right_spec=right_spec,
         )
-        self.diffs = []
 
     def dict_check(
         self,
         path,  # type: PathType
-        left_dict,  # type: typing.Optional[typing.Mapping[typing.Text, typing.Any]]
-        right_dict,  # type: typing.Optional[typing.Mapping[typing.Text, typing.Any]]
+        left_dict,  # type: typing.Union[NoValue, typing.Mapping[typing.Text, typing.Any]]
+        right_dict,  # type: typing.Union[NoValue, typing.Mapping[typing.Text, typing.Any]]
     ):
-        # type: (...) -> None  # noqa
+        # type: (...) -> typing.Iterable[RequiredPropertiesDiff]
         different_properties_mapping = _different_properties_mapping(
             left_spec=self.left_spec,
             right_spec=self.right_spec,
-            left_schema=left_dict,
-            right_schema=right_dict,
+            left_schema=None if isinstance(left_dict, NoValue) else left_dict,
+            right_schema=None if isinstance(right_dict, NoValue) else right_dict,
         )
         if different_properties_mapping:
-            self.diffs.append(RequiredPropertiesDiff(
-                path=path,
-                mapping=different_properties_mapping,
-            ))
+            return (
+                RequiredPropertiesDiff(
+                    path=path,
+                    mapping=different_properties_mapping,
+                ),
+            )
+        else:
+            return ()
 
     def list_check(
         self,
         path,  # type: PathType
-        left_list,  # type: typing.Optional[typing.Sequence[typing.Any]]
-        right_list,  # type: typing.Optional[typing.Sequence[typing.Any]]
+        left_list,  # type: typing.Union[NoValue, typing.Sequence[typing.Any]]
+        right_list,  # type: typing.Union[NoValue, typing.Sequence[typing.Any]]
     ):
-        # type: (...) -> None  # noqa
-        pass
+        # type: (...) -> typing.Iterable[RequiredPropertiesDiff]
+        return ()
 
     def value_check(
         self,
@@ -93,9 +97,5 @@ class RequiredPropertiesDifferWalker(SchemaWalker[RequiredPropertiesDiff]):
         left_value,  # type: typing.Any
         right_value,  # type: typing.Any
     ):
-        # type: (...) -> None
-        pass
-
-    def walk_response(self):
-        # type: () -> typing.List[RequiredPropertiesDiff]
-        return self.diffs
+        # type: (...) -> typing.Iterable[RequiredPropertiesDiff]
+        return ()

--- a/swagger_spec_compatibility/walkers/required_properties.py
+++ b/swagger_spec_compatibility/walkers/required_properties.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import typing
+from itertools import chain
 
 from bravado_core.spec import Spec
 
@@ -35,12 +36,18 @@ def _different_properties_mapping(
         )
 
 
-RequiredPropertiesDiff = typing.NamedTuple(
+class RequiredPropertiesDiff(typing.NamedTuple(
     'RequiredPropertiesDiff', (
         ('path', PathType),
         ('mapping', EntityMapping[typing.Set[typing.Text]]),
     ),
-)
+)):
+    def fix_parameter_path(self, path, original_path):
+        # type: (PathType, PathType) -> 'RequiredPropertiesDiff'
+        return RequiredPropertiesDiff(
+            path=tuple(chain(original_path, self.path[len(original_path):])),
+            mapping=self.mapping,
+        )
 
 
 class RequiredPropertiesDifferWalker(SchemaWalker[RequiredPropertiesDiff]):

--- a/swagger_spec_compatibility/walkers/response_paths.py
+++ b/swagger_spec_compatibility/walkers/response_paths.py
@@ -9,6 +9,7 @@ from bravado_core.spec import Spec
 from bravado_core.util import determine_object_type
 from bravado_core.util import ObjectType
 
+from swagger_spec_compatibility.walkers import NoValue
 from swagger_spec_compatibility.walkers import PathType
 from swagger_spec_compatibility.walkers import SchemaWalker
 
@@ -45,21 +46,23 @@ class ResponsePathsWalker(SchemaWalker[PathType]):
     def dict_check(
         self,
         path,  # type: PathType
-        left_dict,  # type: typing.Optional[typing.Mapping[typing.Text, typing.Any]]
-        right_dict,  # type: typing.Optional[typing.Mapping[typing.Text, typing.Any]]
+        left_dict,  # type: typing.Union[NoValue, typing.Mapping[typing.Text, typing.Any]]
+        right_dict,  # type: typing.Union[NoValue, typing.Mapping[typing.Text, typing.Any]]
     ):
-        # type: (...) -> None  # noqa
+        # type: (...) -> typing.Iterable[PathType]
         if determine_object_type(left_dict) == ObjectType.RESPONSE or determine_object_type(right_dict) == ObjectType.RESPONSE:
-            self.paths.add(path)
+            return (path, )
+        else:
+            return ()
 
     def list_check(
         self,
         path,  # type: PathType
-        left_list,  # type: typing.Optional[typing.Sequence[typing.Any]]
-        right_list,  # type: typing.Optional[typing.Sequence[typing.Any]]
+        left_list,  # type: typing.Union[NoValue, typing.Sequence[typing.Any]]
+        right_list,  # type: typing.Union[NoValue, typing.Sequence[typing.Any]]
     ):
-        # type: (...) -> None  # noqa
-        pass
+        # type: (...) -> typing.Iterable[PathType]
+        return ()
 
     def value_check(
         self,
@@ -67,5 +70,5 @@ class ResponsePathsWalker(SchemaWalker[PathType]):
         left_value,  # type: typing.Any
         right_value,  # type: typing.Any
     ):
-        # type: (...) -> None  # noqa
-        pass
+        # type: (...) -> typing.Iterable[PathType]
+        return ()

--- a/swagger_spec_compatibility/walkers/response_paths.py
+++ b/swagger_spec_compatibility/walkers/response_paths.py
@@ -39,10 +39,6 @@ class ResponsePathsWalker(SchemaWalker[PathType]):
         super(ResponsePathsWalker, self).__init__(left_spec=left_spec, right_spec=right_spec)
         self.paths = set()
 
-    def walk_response(self):
-        # type: () -> typing.Iterable[PathType]
-        return self.paths
-
     def dict_check(
         self,
         path,  # type: PathType

--- a/swagger_spec_compatibility/walkers/response_paths.py
+++ b/swagger_spec_compatibility/walkers/response_paths.py
@@ -3,9 +3,9 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import typing  # noqa: F401
+import typing
 
-from bravado_core.spec import Spec  # noqa: F401
+from bravado_core.spec import Spec
 from bravado_core.util import determine_object_type
 from bravado_core.util import ObjectType
 

--- a/tests/rules/__init___test.py
+++ b/tests/rules/__init___test.py
@@ -3,13 +3,13 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import typing  # noqa: F401
+import typing
 
 import pytest
 
 from swagger_spec_compatibility.rules import compatibility_status
-from swagger_spec_compatibility.rules import RuleProtocol  # noqa: F401
-from swagger_spec_compatibility.rules import ValidationMessage  # noqa: F401
+from swagger_spec_compatibility.rules import RuleProtocol
+from swagger_spec_compatibility.rules import ValidationMessage
 from swagger_spec_compatibility.rules.common import RuleRegistry
 from tests.conftest import DummyRule
 from tests.conftest import DummyRuleFailIfDifferent

--- a/tests/spec_utils_test.py
+++ b/tests/spec_utils_test.py
@@ -9,7 +9,7 @@ import os
 import mock
 import pytest
 import six
-from bravado_core.operation import Operation  # noqa: F401
+from bravado_core.operation import Operation
 
 from swagger_spec_compatibility.cli.common import uri
 from swagger_spec_compatibility.spec_utils import Endpoint

--- a/tests/walkers/__init___test.py
+++ b/tests/walkers/__init___test.py
@@ -9,7 +9,7 @@ from copy import deepcopy
 import mock
 from bravado_core.spec import Spec
 
-from swagger_spec_compatibility.walkers import PathType  # noqa: F401
+from swagger_spec_compatibility.walkers import PathType
 from swagger_spec_compatibility.walkers import SchemaWalker
 
 

--- a/tests/walkers/request_parameters_test.py
+++ b/tests/walkers/request_parameters_test.py
@@ -8,7 +8,7 @@ from swagger_spec_compatibility.walkers.request_parameters import RequestParamet
 
 
 def test_RequestParametersWalker_returns_no_paths_if_no_endpoints_defined(minimal_spec):
-    assert RequestParametersWalker(minimal_spec, minimal_spec).walk() == set()
+    assert set(RequestParametersWalker(minimal_spec, minimal_spec).walk()) == set()
 
 
 def test_RequestParametersWalker_returns_paths_of_endpoints_parameters(minimal_spec, minimal_spec_dict):
@@ -38,6 +38,6 @@ def test_RequestParametersWalker_returns_paths_of_endpoints_parameters(minimal_s
     }
     spec = load_spec_from_spec_dict(minimal_spec_dict)
 
-    assert RequestParametersWalker(spec, spec).walk() == {
+    assert set(RequestParametersWalker(spec, spec).walk()) == {
         ('paths', '/endpoint', 'get', 'parameters', 0),
     }

--- a/tests/walkers/response_paths_test.py
+++ b/tests/walkers/response_paths_test.py
@@ -8,7 +8,7 @@ from swagger_spec_compatibility.walkers.response_paths import ResponsePathsWalke
 
 
 def test_ResponsePathsWalker_returns_no_paths_if_no_endpoints_defined(minimal_spec):
-    assert ResponsePathsWalker(minimal_spec, minimal_spec).walk() == set()
+    assert ResponsePathsWalker(minimal_spec, minimal_spec).walk() == []
 
 
 def test_ResponsePathsWalker_returns_paths_of_endpoints_responses(minimal_spec, minimal_spec_dict):
@@ -29,7 +29,7 @@ def test_ResponsePathsWalker_returns_paths_of_endpoints_responses(minimal_spec, 
     }
     spec = load_spec_from_spec_dict(minimal_spec_dict)
 
-    assert ResponsePathsWalker(spec, spec).walk() == {
+    assert set(ResponsePathsWalker(spec, spec).walk()) == {
         ('paths', '/endpoint', 'get', 'responses', '200'),
         ('paths', '/endpoint', 'get', 'responses', 'default'),
         ('paths', '/endpoint', 'put', 'responses', '403'),


### PR DESCRIPTION
The goal of this PR is to fix a bug noticed internally that is triggered once a parameter is removed from a request.
Due to the nature of the parameters definition (being an array) removing a parameter has the potential to produce _changed type_ alerts due to the fact that all the parameters of the new specs are shifted respect the old specs (check the added integration test for a more concrete example).

In the context of this PR:
 * I've bumped all the pre-commit hooks (so I can remove all the `noqa: F401`) 
 * changed the signature of the `(dict|list|value)_checks` to return an `Iterable[T]` as it simplifies more the interface of the walker (that generally speaking is already complex by itself)


NOTE: tests will most probably be red due to coverage