### PR TITLE
Use venusian to discover rules

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -150,23 +150,21 @@ Use the following steps to define a new rule:
      #  * `description` and `short_name` are reasonably explicative to support `swagger_spec_compatibility explain` command
      #  * `error_code` has REQ- prefix for `RuleType.REQUEST_CONTRACT`, RES- for `RuleType.RESPONSE_CONTRACT` and MIS- for `RuleType.MISCELLANEOUS`
 
-2. Add import into ``swagger_spec_compatibllity/rules/__init__.py`` to allow rule discovery
-
-.. code-block:: python
-
-    from swagger_spec_compatibility.rules.FILE import RuleClassName
 
 3. Add tests to ensure that your rule behaves as expected (tests in ``tests/rules/FILE_test.py``)
 
-4. Add documentation for the defined rule in ``docs/source/rules/ERROR_CODE.rst``. Try to be consistent with the style
+3. Add documentation for the defined rule in ``docs/source/rules/ERROR_CODE.rst``. Try to be consistent with the style
    of the others documentation pages
 
-5. Add example of a Swagger spec change that triggers the rule in ``docs/source/rules/examples/ERROR_CODE.rst``.
+4. Add example of a Swagger spec change that triggers the rule in ``docs/source/rules/examples/ERROR_CODE.rst``.
    Ensure to define a `tester.py` file that will make explicit the backward incompatible change through the usage of a
    `bravado <https://github.com/Yelp/bravado>`_ client (check the other testers for examples).
    **NOTE**: The testers are executed by automated tests, this is intended to ensure that documentation is in sync with
    the codebase.
-
+5. [Optional] Add integration tests to ensure that no regressions will be introduced and/or to validate edge cases of the new rule.
+   Integration tests are defined as follow: ``case-<incremental number>-<number of expected reports>-reports-<short description>`` directory
+   with two files: ``old.yaml`` and ``new.yaml``. The two files represent two versions of the swagger specs that need to be checked for
+   backward compatibility.
 
 Contributing
 ~~~~~~~~~~~~

--- a/docs/source/swagger_spec_compatibility.rst
+++ b/docs/source/swagger_spec_compatibility.rst
@@ -8,6 +8,11 @@ swagger_spec_compatibility Package
 :mod:`swagger_spec_compatibility` Package
 -----------------------------------------
 
+.. automodule:: swagger_spec_compatibility
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 :mod:`cache` Module
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
         'six',
         'termcolor',
         'typing_extensions',
+        'venusian',
     ],
     extras_require={
         ':python_version<"3.5"': ['typing'],
@@ -47,5 +48,6 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 )

--- a/swagger_spec_compatibility/__init__.py
+++ b/swagger_spec_compatibility/__init__.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import venusian
+
+import swagger_spec_compatibility.rules
+
+# Scan the whole library in order to import all the available rules
+venusian.Scanner().scan(swagger_spec_compatibility.rules)

--- a/swagger_spec_compatibility/rules/__init__.py
+++ b/swagger_spec_compatibility/rules/__init__.py
@@ -7,17 +7,9 @@ import typing
 
 from bravado_core.spec import Spec
 
-from swagger_spec_compatibility.rules.added_enum_value_in_response import AddedEnumValueInRequest  # noqa: F401
-from swagger_spec_compatibility.rules.added_properties_in_response_objects_with_additional_properties_set_to_false import AddedPropertiesInResponseObjectsWithAdditionalPropertiesSetToFalse  # noqa: F401,E501
-from swagger_spec_compatibility.rules.added_required_property_in_request import AddedRequiredPropertyInRequest  # noqa: F401
-from swagger_spec_compatibility.rules.changed_type import ChangedType  # noqa: F401
 from swagger_spec_compatibility.rules.common import RuleProtocol
 from swagger_spec_compatibility.rules.common import RuleRegistry
 from swagger_spec_compatibility.rules.common import ValidationMessage
-from swagger_spec_compatibility.rules.deleted_endpoint import DeletedEndpoint  # noqa: F401
-from swagger_spec_compatibility.rules.removed_enum_value_from_request import RemovedEnumValueFromRequest  # noqa: F401
-from swagger_spec_compatibility.rules.removed_properties_from_request_objects_with_additional_properties_set_to_false import RemovedPropertiesFromRequestObjectsWithAdditionalPropertiesSetToFalse  # noqa: F401,E501
-from swagger_spec_compatibility.rules.removed_required_property_from_response import RemovedRequiredPropertyFromResponse  # noqa: F401
 
 
 class _ALL_RULES(object):

--- a/tests/docs_test.py
+++ b/tests/docs_test.py
@@ -37,15 +37,15 @@ def _from_path_to_module(PACKAGE_DIR, path):
 
 def _contain_docstring_or_code(path):
     with open(path) as f:
-        lines_with_no_comments = (
+        lines_with_no_comments = [
             re.sub('(#.*)', '', line.rstrip())
             for line in f.readlines()
-        )
-        not_empty_lines = (
+        ]
+        not_empty_lines = [
             line
             for line in lines_with_no_comments
             if line.strip()
-        )
+        ]
         return any(not_empty_lines)
 
 

--- a/tests/rules/deleted_endpoint_test.py
+++ b/tests/rules/deleted_endpoint_test.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from swagger_spec_compatibility.rules import DeletedEndpoint
+from swagger_spec_compatibility.rules.deleted_endpoint import DeletedEndpoint
 from swagger_spec_compatibility.spec_utils import Endpoint
 from swagger_spec_compatibility.spec_utils import HTTPVerb
 from swagger_spec_compatibility.spec_utils import load_spec_from_spec_dict


### PR DESCRIPTION
The goal of this PR is to remove the manual step of manually importing the rule in `swagger_spec_compatibility.rules` in order to support metaclass-registration.

Scanning the all `swagger_spec_compatibility.rules` is enough to import the different modules and trigger the rules registration process.

This approach has been selected as it removes a manual step from the definition of the rules and `venusian` is a pretty stable library for doing it (it is extensively used into `pyramid`)