### PR TITLE
Add documentation link into error reporting

### DIFF
--- a/swagger_spec_compatibility/rules/common.py
+++ b/swagger_spec_compatibility/rules/common.py
@@ -18,6 +18,13 @@ from termcolor import colored
 from swagger_spec_compatibility.util import wrap
 
 
+def _read_the_docs_link(rule):
+    # type: (typing.Type['RuleProtocol']) -> typing.Text
+    return 'https://swagger-spec-compatibility.readthedocs.io/en/latest/rules/{code}.html'.format(
+        code=rule.error_code,
+    )
+
+
 class RuleRegistry(ABCMeta):
     _REGISTRY = {}  # type: typing.MutableMapping[typing.Text, typing.Type['BaseRule']]
 
@@ -161,10 +168,11 @@ class BaseRule(with_metaclass(RuleRegistry)):
     @classmethod
     def explain(cls):
         # type: () -> typing.Text
-        return '[{error_code}] {short_name}:\n{rule_description}'.format(
+        return '[{error_code}] {short_name}:\n{rule_description}\n\nMore info on: {url}'.format(
             error_code=colored(cls.error_code, attrs=['bold']),
             short_name=colored(cls.short_name, color='cyan', attrs=['bold']),
             rule_description=wrap(cls.description, indent='\t'),
+            url=_read_the_docs_link(cls),
         )
 
     @classmethod

--- a/swagger_spec_compatibility/rules/common.py
+++ b/swagger_spec_compatibility/rules/common.py
@@ -119,17 +119,17 @@ class Level(IntEnum):
 
 class RuleProtocol(typing_extensions.Protocol):
     # Unique identifier of the rule
-    error_code = None  # type: typing.Text
+    error_code = None  # type: typing_extensions.ClassVar[typing.Text]
     # Short name of the rule. This will be visible on CLI in case the rule is triggered
-    short_name = None  # type: typing.Text
+    short_name = None  # type: typing_extensions.ClassVar[typing.Text]
     # Short description of the rationale of the rule. This will be visible on CLI only.
-    description = None  # type: typing.Text
+    description = None  # type: typing_extensions.ClassVar[typing.Text]
     # Error level associated to the rule
-    error_level = None  # type: Level
+    error_level = None  # type: typing_extensions.ClassVar[Level]
     # Type of the rule associated
-    rule_type = None  # type: RuleType
+    rule_type = None  # type: typing_extensions.ClassVar[RuleType]
     # Documentation link
-    documentation_link = None  # type: typing.Text
+    documentation_link = None  # type: typing_extensions.ClassVar[typing.Optional[typing.Text]]
 
     @classmethod
     def validate(cls, left_spec, right_spec):
@@ -166,17 +166,17 @@ class ValidationMessage(typing.NamedTuple(
 
 class BaseRule(with_metaclass(RuleRegistry)):
     # Unique identifier of the rule
-    error_code = None  # type: typing.Text
+    error_code = None  # type: typing_extensions.ClassVar[typing.Text]
     # Short name of the rule. This will be visible on CLI in case the rule is triggered
-    short_name = None  # type: typing.Text
+    short_name = None  # type: typing_extensions.ClassVar[typing.Text]
     # Short description of the rationale of the rule. This will be visible on CLI only.
-    description = None  # type: typing.Text
+    description = None  # type: typing_extensions.ClassVar[typing.Text]
     # Error level associated to the rule
-    error_level = None  # type: Level
+    error_level = None  # type: typing_extensions.ClassVar[Level]
     # Type of the rule associated
-    rule_type = None  # type: RuleType
+    rule_type = None  # type: typing_extensions.ClassVar[RuleType]
     # Documentation link
-    documentation_link = None  # type: typing.Text
+    documentation_link = None  # type: typing_extensions.ClassVar[typing.Optional[typing.Text]]
 
     def __init__(self):
         # type: () -> None

--- a/swagger_spec_compatibility/rules/common.py
+++ b/swagger_spec_compatibility/rules/common.py
@@ -128,10 +128,11 @@ class ValidationMessage(typing.NamedTuple(
 )):
     def string_representation(self):
         # type: () -> typing.Text
-        return '[{error_code}] {short_name} : {reference}'.format(
+        return '[{error_code}] {short_name}: {reference} (documentation: {documentation})'.format(
             error_code=self.rule.error_code,
             reference=self.reference,
             short_name=self.rule.short_name,
+            documentation=_read_the_docs_link(self.rule),
         )
 
     def json_representation(self):
@@ -140,6 +141,7 @@ class ValidationMessage(typing.NamedTuple(
             'error_code': self.rule.error_code,
             'reference': self.reference,
             'short_name': self.rule.short_name,
+            'documentation': _read_the_docs_link(self.rule),
         }
 
 

--- a/swagger_spec_compatibility/rules/common.py
+++ b/swagger_spec_compatibility/rules/common.py
@@ -25,6 +25,22 @@ def _read_the_docs_link(rule):
     )
 
 
+def get_rule_documentation_link(rule):
+    # type: (typing.Type['RuleProtocol']) -> typing.Optional[typing.Text]
+    """
+    Helper method that allows to extract documentation link related to a given rule.
+
+    If the rule is implemented within swagger-spec-compatibility library then the documentation
+    link will fall back to the "default" read-the-docs link
+    """
+    if rule.documentation_link:
+        return rule.documentation_link
+    elif rule.__module__.startswith('swagger_spec_compatibility.rules'):
+        return _read_the_docs_link(rule)
+    else:
+        return None
+
+
 class RuleRegistry(ABCMeta):
     _REGISTRY = {}  # type: typing.MutableMapping[typing.Text, typing.Type['BaseRule']]
 
@@ -53,8 +69,8 @@ class RuleRegistry(ABCMeta):
         cls_fully_qualified_name = '{}.{}'.format(cls.__module__, cls.__name__)
         base_rule_fully_qualified_name = '{}.BaseRule'.format(mcs.__module__)
         assert (  # pragma: no branch
-            cls_fully_qualified_name == base_rule_fully_qualified_name or
-            any(base_rule_fully_qualified_name == '{}.{}'.format(c.__module__, c.__name__) for c in cls.__bases__)
+            cls_fully_qualified_name == base_rule_fully_qualified_name
+            or any(base_rule_fully_qualified_name == '{}.{}'.format(c.__module__, c.__name__) for c in cls.__bases__)
         ), '{} metaclass should be used only by {}.BaseRule'.format(mcs, mcs.__module__)
 
     def __new__(mcs, name, bases, namespace):
@@ -112,6 +128,8 @@ class RuleProtocol(typing_extensions.Protocol):
     error_level = None  # type: Level
     # Type of the rule associated
     rule_type = None  # type: RuleType
+    # Documentation link
+    documentation_link = None  # type: typing.Text
 
     @classmethod
     def validate(cls, left_spec, right_spec):
@@ -128,11 +146,12 @@ class ValidationMessage(typing.NamedTuple(
 )):
     def string_representation(self):
         # type: () -> typing.Text
-        return '[{error_code}] {short_name}: {reference} (documentation: {documentation})'.format(
+        documentation_link = get_rule_documentation_link(self.rule)
+        return '[{error_code}] {short_name}: {reference}{more_info}'.format(
             error_code=self.rule.error_code,
             reference=self.reference,
             short_name=self.rule.short_name,
-            documentation=_read_the_docs_link(self.rule),
+            more_info=' (documentation: {})'.format(documentation_link) if documentation_link else '',
         )
 
     def json_representation(self):
@@ -141,7 +160,7 @@ class ValidationMessage(typing.NamedTuple(
             'error_code': self.rule.error_code,
             'reference': self.reference,
             'short_name': self.rule.short_name,
-            'documentation': _read_the_docs_link(self.rule),
+            'documentation': get_rule_documentation_link(self.rule),
         }
 
 
@@ -156,6 +175,8 @@ class BaseRule(with_metaclass(RuleRegistry)):
     error_level = None  # type: Level
     # Type of the rule associated
     rule_type = None  # type: RuleType
+    # Documentation link
+    documentation_link = None  # type: typing.Text
 
     def __init__(self):
         # type: () -> None
@@ -170,11 +191,12 @@ class BaseRule(with_metaclass(RuleRegistry)):
     @classmethod
     def explain(cls):
         # type: () -> typing.Text
-        return '[{error_code}] {short_name}:\n{rule_description}\n\nMore info on: {url}'.format(
+        documentation_link = get_rule_documentation_link(cls)
+        return '[{error_code}] {short_name}:\n{rule_description}{more_info}'.format(
             error_code=colored(cls.error_code, attrs=['bold']),
             short_name=colored(cls.short_name, color='cyan', attrs=['bold']),
             rule_description=wrap(cls.description, indent='\t'),
-            url=_read_the_docs_link(cls),
+            more_info='\n\nMore info on {}'.format(documentation_link) if documentation_link else '',
         )
 
     @classmethod

--- a/tests/cli/run_test.py
+++ b/tests/cli/run_test.py
@@ -12,6 +12,7 @@ from swagger_spec_compatibility.cli.run import _Namespace
 from swagger_spec_compatibility.cli.run import _print_json_messages
 from swagger_spec_compatibility.cli.run import _print_raw_messages
 from swagger_spec_compatibility.cli.run import execute
+from swagger_spec_compatibility.rules.changed_type import ChangedType
 from swagger_spec_compatibility.rules.common import Level
 from tests.conftest import DummyWarningRule
 
@@ -33,6 +34,11 @@ def cli_args():
 @pytest.fixture
 def warning_message():
     return DummyWarningRule.validation_message('reference')
+
+
+@pytest.fixture
+def error_message_library_rule():
+    return ChangedType.validation_message('reference')
 
 
 @pytest.mark.parametrize('json_output', [True, False])
@@ -64,25 +70,29 @@ def test_execute(
     capsys.readouterr()
 
 
-def test__print_raw_messages(capsys, warning_message):
+def test__print_raw_messages(capsys, warning_message, error_message_library_rule):
     _print_raw_messages(
         messages_by_level={
             Level.INFO: [],
             Level.WARNING: [warning_message],
+            Level.ERROR: [error_message_library_rule],
         },
     )
     out, _ = capsys.readouterr()
     assert out == 'WARNING rules:\n' \
-        '\t[TEST_WARNING_MSG] DummyWarningRule: reference ' \
-        '(documentation: https://swagger-spec-compatibility.readthedocs.io/en/latest/rules/TEST_WARNING_MSG.html)' \
-        '\n'
+                  '\t[TEST_WARNING_MSG] DummyWarningRule: reference\n' \
+                  'ERROR rules:\n' \
+                  '\t[MIS-E002] Changed type: reference (documentation: ' \
+                  'https://swagger-spec-compatibility.readthedocs.io/en/latest/rules/MIS-E002.html)' \
+                  '\n'
 
 
-def test__print_json_messages(capsys, warning_message):
+def test__print_json_messages(capsys, warning_message, error_message_library_rule):
     _print_json_messages(
         messages_by_level={
             Level.INFO: [],
             Level.WARNING: [warning_message],
+            Level.ERROR: [error_message_library_rule],
         },
     )
     out, _ = capsys.readouterr()
@@ -92,7 +102,15 @@ def test__print_json_messages(capsys, warning_message):
                 'error_code': 'TEST_WARNING_MSG',
                 'reference': 'reference',
                 'short_name': 'DummyWarningRule',
-                'documentation': 'https://swagger-spec-compatibility.readthedocs.io/en/latest/rules/TEST_WARNING_MSG.html',
+                'documentation': None,
+            },
+        ],
+        'ERROR': [
+            {
+                'documentation': 'https://swagger-spec-compatibility.readthedocs.io/en/latest/rules/MIS-E002.html',
+                'error_code': 'MIS-E002',
+                'reference': 'reference',
+                'short_name': 'Changed type',
             },
         ],
     }

--- a/tests/cli/run_test.py
+++ b/tests/cli/run_test.py
@@ -73,7 +73,8 @@ def test__print_raw_messages(capsys, warning_message):
     )
     out, _ = capsys.readouterr()
     assert out == 'WARNING rules:\n' \
-        '\t[TEST_WARNING_MSG] DummyWarningRule : reference' \
+        '\t[TEST_WARNING_MSG] DummyWarningRule: reference ' \
+        '(documentation: https://swagger-spec-compatibility.readthedocs.io/en/latest/rules/TEST_WARNING_MSG.html)' \
         '\n'
 
 
@@ -91,6 +92,7 @@ def test__print_json_messages(capsys, warning_message):
                 'error_code': 'TEST_WARNING_MSG',
                 'reference': 'reference',
                 'short_name': 'DummyWarningRule',
+                'documentation': 'https://swagger-spec-compatibility.readthedocs.io/en/latest/rules/TEST_WARNING_MSG.html',
             },
         ],
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,6 +105,19 @@ class DummyErrorRule(BaseRule):
         return (cls.validation_message('test'),)
 
 
+class DummyRuleWithDocumentationLink(BaseRule):
+    error_code = 'TEST_DOCUMENTATION_LINK'
+    error_level = Level.INFO
+    description = 'Rule description'
+    rule_type = RuleType.MISCELLANEOUS
+    short_name = 'DummyRuleWithDocLink'
+    documentation_link = 'link'
+
+    @classmethod
+    def validate(cls, left_spec, right_spec):  # pragma: no cover
+        return ()
+
+
 @pytest.fixture
 def mock_RuleRegistry():
     with mock.patch.object(

--- a/tests/rules/common_test.py
+++ b/tests/rules/common_test.py
@@ -6,10 +6,25 @@ from __future__ import unicode_literals
 import mock
 import pytest
 
+from swagger_spec_compatibility.rules.changed_type import ChangedType
+from swagger_spec_compatibility.rules.common import get_rule_documentation_link
 from swagger_spec_compatibility.rules.common import Level
 from swagger_spec_compatibility.rules.common import RuleRegistry
 from swagger_spec_compatibility.rules.common import ValidationMessage
 from tests.conftest import DummyRule
+from tests.conftest import DummyRuleWithDocumentationLink
+
+
+@pytest.mark.parametrize(
+    'rule, expected_link',
+    [
+        (DummyRule, None),
+        (ChangedType, 'https://swagger-spec-compatibility.readthedocs.io/en/latest/rules/MIS-E002.html'),
+        (DummyRuleWithDocumentationLink, DummyRuleWithDocumentationLink.documentation_link),
+    ],
+)
+def test_get_rule_documentation_link(rule, expected_link):
+    assert get_rule_documentation_link(rule) == expected_link
 
 
 def test_RuleRegistry_rule_names(mock_RuleRegistry):
@@ -42,9 +57,7 @@ def test_ValidationMessage_string_representation():
         level=Level.ERROR,
         rule=DummyRule,
         reference='reference',
-    ).string_representation() == \
-        '[TEST_NO_MSG] DummyRule: reference ' \
-        '(documentation: https://swagger-spec-compatibility.readthedocs.io/en/latest/rules/TEST_NO_MSG.html)'
+    ).string_representation() == '[TEST_NO_MSG] DummyRule: reference'
 
 
 def test_initializing_BaseRule_throws_an_exception():

--- a/tests/rules/common_test.py
+++ b/tests/rules/common_test.py
@@ -42,7 +42,9 @@ def test_ValidationMessage_string_representation():
         level=Level.ERROR,
         rule=DummyRule,
         reference='reference',
-    ).string_representation() == '[TEST_NO_MSG] DummyRule : reference'
+    ).string_representation() == \
+        '[TEST_NO_MSG] DummyRule: reference ' \
+        '(documentation: https://swagger-spec-compatibility.readthedocs.io/en/latest/rules/TEST_NO_MSG.html)'
 
 
 def test_initializing_BaseRule_throws_an_exception():


### PR DESCRIPTION
The goal of this PR is to make explicit the link to the documentation page where the reporting is detailed explained.