### PR TITLE
Update CLI interaction

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,10 +50,7 @@ The commands below assume that the library is already installed
 .. code-block:: bash
 
     $ swagger_spec_compatibility -h
-
-    usage: swagger_spec_compatibility [-h]
-                                  [-r {MIS-E001,MIS-E002,REQ-E001,REQ-E002,REQ-E003,RES-E001,RES-E002,RES-E003} [{MIS-E001,MIS-E002,REQ-E001,REQ-E002,REQ-E003,RES-E001,RES-E002,RES-E003} ...]]
-                                  {explain,run} ...
+    usage: swagger_spec_compatibility [-h] {explain,info,run} ...
 
     Tool for the identification of backward incompatible changes between two swagger specs.
 
@@ -62,20 +59,17 @@ The commands below assume that the library is already installed
     - ERROR: new Swagger spec does introduce a breaking change respect the old implementation
 
     positional arguments:
-      {explain,run}         help for sub-command
-        explain             explain selected rules
-        run                 run backward compatibility detection
+      {explain,info,run}  help for sub-command
+        explain           explain selected rules
+        info              Reports tool's information
+        run               run backward compatibility detection
 
     optional arguments:
-      -h, --help            show this help message and exit
-      -r {MIS-E001,MIS-E002,REQ-E001,REQ-E002,REQ-E003,RES-E001,RES-E002,RES-E003} [{MIS-E001,MIS-E002,REQ-E001,REQ-E002,REQ-E003,RES-E001,RES-E002,RES-E003} ...], --rules {MIS-E001,MIS-E002,REQ-E001,REQ-E002,REQ-E003,RES-E001,RES-E002,RES-E003} [{MIS-E001,MIS-E002,REQ-E001,REQ-E002,REQ-E003,RES-E001,RES-E002,RES-E003} ...]
-                            Rules to apply for compatibility detection. (default:
-                            ['MIS-E001', 'MIS-E002', 'REQ-E001', 'REQ-E002',
-                            'REQ-E003', 'RES-E001', 'RES-E002', 'RES-E003'])
+      -h, --help          show this help message and exit
 
 .. code-block:: bash
 
-    $ swagger_spec_compatibility explain -r=REQ-E001 -r=REQ-E002 explain
+    $ swagger_spec_compatibility explain -r REQ-E001 REQ-E002
     Rules explanation
     [REQ-E001] Added Required Property in Request contract:
     	Adding a required property to an object used in requests leads client request to fail if the property is not present.
@@ -100,6 +94,22 @@ The commands below assume that the library is already installed
     $ swagger_spec_compatibility -r=MIS-E001 -r=MIS-E002 run ${old_spec_path} ${new_spec_path}
     $ echo $?
     0
+
+.. code-block:: bash
+
+    $ swagger_spec_compatibility info
+    swagger-spec-compatibility: 1.3.0
+    Python version: CPython - 3.6.9
+    Python compiler: GCC 4.2.1 Compatible Apple LLVM 10.0.1 (clang-1001.0.46.4)
+    Discovered rules:
+        MIS-E001: swagger_spec_compatibility.rules.deleted_endpoint.DeletedEndpoint
+        MIS-E002: swagger_spec_compatibility.rules.changed_type.ChangedType
+        REQ-E001: swagger_spec_compatibility.rules.added_required_property_in_request.AddedRequiredPropertyInRequest
+        REQ-E002: swagger_spec_compatibility.rules.removed_enum_value_from_request.RemovedEnumValueFromRequest
+        REQ-E003: swagger_spec_compatibility.rules.removed_properties_from_request_objects_with_additional_properties_set_to_false.RemovedPropertiesFromRequestObjectsWithAdditionalPropertiesSetToFalse
+        RES-E001: swagger_spec_compatibility.rules.added_properties_in_response_objects_with_additional_properties_set_to_false.AddedPropertiesInResponseObjectsWithAdditionalPropertiesSetToFalse
+        RES-E002: swagger_spec_compatibility.rules.removed_required_property_from_response.RemovedRequiredPropertyFromResponse
+        RES-E003: swagger_spec_compatibility.rules.added_enum_value_in_response.AddedEnumValueInRequest
 
 Development
 -----------

--- a/docs/source/swagger_spec_compatibility.rst
+++ b/docs/source/swagger_spec_compatibility.rst
@@ -39,6 +39,11 @@ swagger_spec_compatibility Package
     :undoc-members:
     :show-inheritance:
 
+.. automodule:: swagger_spec_compatibility.cli.info
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 .. automodule:: swagger_spec_compatibility.cli.run
     :members:
     :undoc-members:

--- a/swagger_spec_compatibility/__main__.py
+++ b/swagger_spec_compatibility/__main__.py
@@ -6,11 +6,12 @@ from __future__ import unicode_literals
 import typing
 
 from swagger_spec_compatibility.cli import parser
+from swagger_spec_compatibility.cli.common import post_process_rules_cli_arguments
 
 
 def main(argv=None):
     # type: (typing.Optional[typing.Sequence[typing.Text]]) -> int
-    args = parser().parse_args(argv)
+    args = post_process_rules_cli_arguments(parser().parse_args(argv))
     exit_code = args.func(args)  # type: int
     return exit_code
 

--- a/swagger_spec_compatibility/cli/__init__.py
+++ b/swagger_spec_compatibility/cli/__init__.py
@@ -10,7 +10,6 @@ from six import iteritems
 
 from swagger_spec_compatibility.cli import explain
 from swagger_spec_compatibility.cli import run
-from swagger_spec_compatibility.cli.common import cli_rules
 from swagger_spec_compatibility.util import wrap
 
 
@@ -23,7 +22,7 @@ _SUB_COMMAND_ASSOCIATED_FUNCTION_MAPPING = {
 def parser():
     # type: () -> argparse.ArgumentParser
 
-    parser = argparse.ArgumentParser(
+    argument_parser = argparse.ArgumentParser(
         description=wrap(dedent("""
             Tool for the identification of backward incompatible changes between two swagger specs.
 
@@ -34,29 +33,9 @@ def parser():
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
 
-    rules = cli_rules()
-    mutex_group = parser.add_mutually_exclusive_group()
-    mutex_group.add_argument(
-        '-r', '--rules',
-        nargs='+',
-        help='Rules to apply for compatibility detection. (default: %(default)s)',
-        default=rules,
-        choices=rules,
-    )
-    mutex_group.add_argument(
-        '-b', '--blacklist-rules',
-        nargs='+',
-        help='Rules to ignore for compatibility detection. (default: %(default)s)',
-        default=[],
-        choices=rules,
-    )
-
-    subparsers = parser.add_subparsers(help='help for sub-command', dest='command')
+    subparsers = argument_parser.add_subparsers(help='help for sub-command', dest='command')
     subparsers.required = True
     for add_sub_command_parser, associated_function in iteritems(_SUB_COMMAND_ASSOCIATED_FUNCTION_MAPPING):
         add_sub_command_parser(subparsers).set_defaults(func=associated_function)
 
-    if not rules:
-        raise parser.error('No rules are defined.')
-
-    return parser
+    return argument_parser

--- a/swagger_spec_compatibility/cli/__init__.py
+++ b/swagger_spec_compatibility/cli/__init__.py
@@ -9,12 +9,14 @@ from textwrap import dedent
 from six import iteritems
 
 from swagger_spec_compatibility.cli import explain
+from swagger_spec_compatibility.cli import info
 from swagger_spec_compatibility.cli import run
 from swagger_spec_compatibility.util import wrap
 
 
 _SUB_COMMAND_ASSOCIATED_FUNCTION_MAPPING = {
     explain.add_sub_parser: explain.execute,
+    info.add_sub_parser: info.execute,
     run.add_sub_parser: run.execute,
 }
 

--- a/swagger_spec_compatibility/cli/common.py
+++ b/swagger_spec_compatibility/cli/common.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import argparse
 import typing
 from argparse import ArgumentTypeError
 from os.path import abspath
@@ -56,3 +57,47 @@ def rules(cli_args):
         # so we're guaranteed to have at least one set to it's default value
         if rule_name not in cli_args.blacklist_rules
     }
+
+
+def add_rules_arguments(argument_parser):
+    # type: (argparse.ArgumentParser) -> None
+    rules = cli_rules()
+    if not rules:
+        raise argument_parser.error('No rules are defined.')
+
+    mutex_group = argument_parser.add_mutually_exclusive_group()
+    mutex_group.add_argument(
+        '-r', '--rules',
+        action='append',
+        choices=rules,
+        dest='rules',
+        help='Rules to apply for compatibility detection. (default: [%(choices)s])',
+        nargs='+',
+    )
+    mutex_group.add_argument(
+        '-b', '--blacklist-rules',
+        action='append',
+        choices=rules,
+        dest='blacklist_rules',
+        help='Rules to ignore for compatibility detection. (By default no rules are blacklisted)',
+        nargs='+',
+    )
+
+
+def post_process_rules_cli_arguments(args):
+    # type: (argparse.Namespace) -> argparse.Namespace
+    def _extract_rules(field, default_value):
+        # type: (typing.Text, typing.Iterable[typing.Text]) -> None
+        if hasattr(args, field):  # pragma: no branch
+            if getattr(args, field):
+                setattr(
+                    args, field,
+                    list({rule for rules in getattr(args, field) for rule in rules}),
+                )
+            else:
+                setattr(args, field, default_value)
+
+    _extract_rules('rules', cli_rules())
+    _extract_rules('blacklist_rules', [])
+
+    return args

--- a/swagger_spec_compatibility/cli/explain.py
+++ b/swagger_spec_compatibility/cli/explain.py
@@ -8,6 +8,7 @@ import typing
 
 from termcolor import colored
 
+from swagger_spec_compatibility.cli.common import add_rules_arguments
 from swagger_spec_compatibility.cli.common import CLIProtocol
 from swagger_spec_compatibility.cli.common import rules
 
@@ -34,4 +35,6 @@ def execute(cli_args):
 
 def add_sub_parser(subparsers):
     # type: (argparse._SubParsersAction) -> argparse.ArgumentParser
-    return subparsers.add_parser('explain', help='explain selected rules')
+    explain_parser = subparsers.add_parser('explain', help='explain selected rules')
+    add_rules_arguments(explain_parser)
+    return explain_parser

--- a/swagger_spec_compatibility/cli/info.py
+++ b/swagger_spec_compatibility/cli/info.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import argparse
+import platform
+
+import pkg_resources
+
+from swagger_spec_compatibility.cli.common import cli_rules
+from swagger_spec_compatibility.cli.common import CLIProtocol
+from swagger_spec_compatibility.rules import RuleRegistry
+
+
+def execute(cli_args):  # pragma: no cover
+    # type: (CLIProtocol) -> int
+    print(
+        'swagger-spec-compatibility: {swagger_spec_compatibility_version}\n'
+        'Python version: {python_implementation} - {python_version}\n'
+        'Python compiler: {python_compiler}\n'
+        'Discovered rules:\n    {rules}'.format(
+            swagger_spec_compatibility_version=pkg_resources.get_distribution('swagger-spec-compatibility').version,
+            python_implementation=platform.python_implementation(),
+            python_version=platform.python_version(),
+            python_compiler=platform.python_compiler(),
+            rules='\n    '.join(
+                '{rule_name}: {rule.__module__}.{rule.__name__}'.format(rule_name=rule_name, rule=RuleRegistry.rule(rule_name))
+                for rule_name in cli_rules()
+            ),
+        ),
+    )
+
+    return 0
+
+
+def add_sub_parser(subparsers):
+    # type: (argparse._SubParsersAction) -> argparse.ArgumentParser
+    return subparsers.add_parser('info', help='Reports tool\'s information')

--- a/swagger_spec_compatibility/cli/run.py
+++ b/swagger_spec_compatibility/cli/run.py
@@ -10,6 +10,7 @@ import typing
 
 from six import iteritems
 
+from swagger_spec_compatibility.cli.common import add_rules_arguments
 from swagger_spec_compatibility.cli.common import CLIProtocol
 from swagger_spec_compatibility.cli.common import rules
 from swagger_spec_compatibility.cli.common import uri
@@ -98,6 +99,9 @@ def execute(cli_args):
 def add_sub_parser(subparsers):
     # type: (argparse._SubParsersAction) -> argparse.ArgumentParser
     run_detection_parser = subparsers.add_parser('run', help='run backward compatibility detection')
+
+    add_rules_arguments(run_detection_parser)
+
     run_detection_parser.add_argument(
         '--strict',
         action='store_true',

--- a/tests/__main___test.py
+++ b/tests/__main___test.py
@@ -3,10 +3,14 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import mock
 import pytest
 
+from swagger_spec_compatibility import cli
 from swagger_spec_compatibility.__main__ import main
+from swagger_spec_compatibility.cli.common import add_rules_arguments
 from tests.conftest import DummyRule
+from tests.conftest import MOCKED_RULE_REGISTRY
 
 
 def test_main_fails_with_no_command(capsys):
@@ -33,3 +37,41 @@ def test_main_run_succeed(mock_SwaggerClient, mock_RuleRegistry_empty, capsys):
     mock_RuleRegistry_empty['DummyRule'] = DummyRule
     assert main(['run', __file__, __file__]) == 0
     capsys.readouterr()
+
+
+@pytest.mark.parametrize(
+    'cli_args, expected_rules, expected_blacklist_rules',
+    [
+        # Default values
+        [['test'], MOCKED_RULE_REGISTRY.keys(), []],
+        # Rules
+        [['test', '-r', 'DummyRule'], ['DummyRule'], []],
+        [['test', '-r', 'DummyRule', 'DummyRule'], ['DummyRule'], []],
+        [['test', '-r', 'DummyRule', 'DummyErrorRule'], ['DummyRule', 'DummyErrorRule'], []],
+        [['test', '-r', 'DummyRule', '-r', 'DummyErrorRule'], ['DummyRule', 'DummyErrorRule'], []],
+
+        # Blacklist rules
+        [['test', '-b', 'DummyRule'], MOCKED_RULE_REGISTRY.keys(), ['DummyRule']],
+        [['test', '-b', 'DummyRule', 'DummyRule'], MOCKED_RULE_REGISTRY.keys(), ['DummyRule']],
+        [['test', '-b', 'DummyRule', 'DummyErrorRule'], MOCKED_RULE_REGISTRY.keys(), ['DummyRule', 'DummyErrorRule']],
+        [['test', '-b', 'DummyRule', '-b', 'DummyErrorRule'], MOCKED_RULE_REGISTRY.keys(), ['DummyRule', 'DummyErrorRule']],
+    ],
+)
+def test_post_process_rules_cli_arguments(mock_RuleRegistry, cli_args, expected_rules, expected_blacklist_rules):
+    def add_sub_parser(subparsers):
+        explain_parser = subparsers.add_parser('test')
+        add_rules_arguments(explain_parser)
+        return explain_parser
+
+    execute_function = mock.Mock(name='test associated function')
+
+    with mock.patch.object(
+        cli, '_SUB_COMMAND_ASSOCIATED_FUNCTION_MAPPING',
+        {add_sub_parser: execute_function},
+    ):
+        main(cli_args)
+
+    args = execute_function.call_args.args[0]
+    assert args.func == execute_function
+    assert set(args.rules) == set(expected_rules)
+    assert set(args.blacklist_rules) == set(expected_blacklist_rules)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,16 +118,19 @@ class DummyRuleWithDocumentationLink(BaseRule):
         return ()
 
 
+MOCKED_RULE_REGISTRY = {
+    'DummyRule': DummyRule,
+    'DummyInfoRule': DummyInfoRule,
+    'DummyWarningRule': DummyWarningRule,
+    'DummyErrorRule': DummyErrorRule,
+    'DummyRuleFailIfDifferent': DummyRuleFailIfDifferent,
+}
+
+
 @pytest.fixture
 def mock_RuleRegistry():
     with mock.patch.object(
-            RuleRegistry, '_REGISTRY', {
-                'DummyRule': DummyRule,
-                'DummyInfoRule': DummyInfoRule,
-                'DummyWarningRule': DummyWarningRule,
-                'DummyErrorRule': DummyErrorRule,
-                'DummyRuleFailIfDifferent': DummyRuleFailIfDifferent,
-            },
+        RuleRegistry, '_REGISTRY', MOCKED_RULE_REGISTRY,
     ) as m:
         yield m
 


### PR DESCRIPTION
The goal of this change is to ensure that:
 * in case multiple rules (or blacklist rules) are passed via the CLI they will be honored, before this change only the last rule would be honored
 * improve ergonomics: rules should be defined after the main command (explain, run, etc) such that no weird errors are raised (ie. `invalid choice: 'run' (choose from 'MIS-E001', 'MIS-E002', ...)`)
 * provide `info` command: useful while integrating it on CI systems as well as during issues creation


