### PR TITLE
Allow rule discovery from cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 *.egg-info
 *.py[co]
 /.cache
-/.coverage
+/.coverage*
 /.idea/
 /.mypy_cache/
 /.pytest_cache

--- a/swagger_spec_compatibility/__main__.py
+++ b/swagger_spec_compatibility/__main__.py
@@ -7,10 +7,12 @@ import typing
 
 from swagger_spec_compatibility.cli import parser
 from swagger_spec_compatibility.cli.common import post_process_rules_cli_arguments
+from swagger_spec_compatibility.cli.common import pre_process_cli_to_discover_rules
 
 
 def main(argv=None):
     # type: (typing.Optional[typing.Sequence[typing.Text]]) -> int
+    pre_process_cli_to_discover_rules(argv)
     args = post_process_rules_cli_arguments(parser().parse_args(argv))
     exit_code = args.func(args)  # type: int
     return exit_code

--- a/swagger_spec_compatibility/cli/common.py
+++ b/swagger_spec_compatibility/cli/common.py
@@ -104,6 +104,7 @@ def add_rules_arguments(argument_parser):
         choices=rules,
         dest='rules',
         help='Rules to apply for compatibility detection. (default: [%(choices)s])',
+        metavar='RULE',
         nargs='+',
     )
     mutex_group.add_argument(
@@ -112,6 +113,7 @@ def add_rules_arguments(argument_parser):
         choices=rules,
         dest='blacklist_rules',
         help='Rules to ignore for compatibility detection. (By default no rules are blacklisted)',
+        metavar='RULE',
         nargs='+',
     )
 

--- a/swagger_spec_compatibility/cli/common.py
+++ b/swagger_spec_compatibility/cli/common.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import argparse
+import os
 import typing
 import warnings
 from argparse import ArgumentTypeError
@@ -22,6 +23,9 @@ from venusian import Scanner
 
 from swagger_spec_compatibility.rules.common import BaseRule
 from swagger_spec_compatibility.rules.common import RuleRegistry
+
+
+_ENV_VARIABLE = str('CUSTOM_RULE_PACKAGES')
 
 
 class CLIProtocol(typing_extensions.Protocol):
@@ -62,13 +66,28 @@ def rules(cli_args):
     }
 
 
+def _get_rule_discovery_from_env():
+    # type: () -> typing.List[typing.Text]
+    return [
+        value
+        for value in (
+            part.strip()
+            for part in os.environ.get(_ENV_VARIABLE, '').split(',')
+        )
+        if value
+    ]
+
+
 def add_rule_discovery_argument(argument_parser):
     # type: (argparse.ArgumentParser) -> None
     argument_parser.add_argument(
         '-d', '--discover-rules-from',
         action='append',
+        default=[_get_rule_discovery_from_env()],
         dest='packages_to_discover_rules_from',
-        help='Non-standard packages to load rules from',
+        help='Non-standard packages to load rules from. '
+             'The values can be defined as CSV in the {} '
+             'environmental variable'.format(_ENV_VARIABLE),
         nargs='+',
     )
 

--- a/swagger_spec_compatibility/cli/info.py
+++ b/swagger_spec_compatibility/cli/info.py
@@ -8,6 +8,7 @@ import platform
 
 import pkg_resources
 
+from swagger_spec_compatibility.cli.common import add_rule_discovery_argument
 from swagger_spec_compatibility.cli.common import cli_rules
 from swagger_spec_compatibility.cli.common import CLIProtocol
 from swagger_spec_compatibility.rules import RuleRegistry
@@ -36,4 +37,6 @@ def execute(cli_args):  # pragma: no cover
 
 def add_sub_parser(subparsers):
     # type: (argparse._SubParsersAction) -> argparse.ArgumentParser
-    return subparsers.add_parser('info', help='Reports tool\'s information')
+    info_parser = subparsers.add_parser('info', help='Reports tool\'s information')
+    add_rule_discovery_argument(info_parser)
+    return info_parser


### PR DESCRIPTION
The goal of this PR is to allow the CLI tool to discover detection rules via:
 * env variable: `CUSTOM_RULE_PACKAGES` (a comma separated list of packages)
 * cli argument: `--discover-rules-from`

This is to allow discovery of rules (not defined within the tool) while using the tool via CLI.
