### PR TITLE
swagger-spec-compatibility is not compatible with bravado-core==5.16.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     url='https://github.com/Yelp/swagger-spec-compatibility',
     install_requires=[
         'bravado',
-        'bravado-core',
+        'bravado-core != 5.16.0',
         'swagger-spec-validator',
         'six',
         'termcolor',


### PR DESCRIPTION
As highlighted by @garyhoren, using a fresh install of swagger-spec-compatibility raises
```
TypeError: unhashable type: 'Spec'
```
This is caused because the latest bravado-core version (5.16.0) has changed the hashability propery of `bravado_core.spec.Spec` instances. More details are available on https://github.com/Yelp/bravado-core/pull/363.

In order to limit the bleeding of the issue, I'm updating the requirements of the package by highlighting the incompatibility by blacklisting version `5.16.0` of `bravado-core`.

This PR will fix the tests of the package, that are currently red