### PR TITLE
Create issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Please provide information about:
+1. Initial Swagger Spec (old version)
+2. Modified Swagger Spec (new version)
+3. Executed command
+
+Note: Please provide a minimal case of spec as it helps more in identifying the issue and fixing it.
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Platform:**
+ - OS: [e.g. Windows, Linux, ...]
+ - Python interpreter: [output of `python -VV`]
+ - Library Version: [output of `pip show swagger-spec-compatibility`]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is.
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
The goal of this PR is to provide a quick access to pre-defined templates while opening issues.

This is mostly helpful to guide contributors / users of the library to provide more detailed content such that they might get more accurate answers without having to round-trip multiple times (ie. missing some info, etc.)

This does not alter the capability to open issues in a "free" form, it just provides an alternative :)