### PR TITLE
Fix AdditionalPropertiesDifferWalker when additionalProperties contains cycles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ install-hooks: venv
 	./venv/bin/pre-commit install -f --install-hooks
 
 venv: requirements-dev.txt requirements-docs.txt setup.py tox.ini
-	-deactivate
 	rm -rf venv
 	tox -e venv
 


### PR DESCRIPTION
Internal ticket: MOBAPISERV-2427

We discovered that the `AdditionalPropertiesDifferWalker` can fail with a recursion error when the `additionalProperties` objects it is inspecting contain cycles. Cycles are (apparently) allowed under Swagger, so we should be able to handle them without erroring.

The recursion error happens at this line when comparing the two dictionaries:
https://github.com/Yelp/swagger-spec-compatibility/blob/b1c77e999d54e00739f69e5a72df20fbccaaf2ce/swagger_spec_compatibility/walkers/additional_properties.py#L62

Here's what these values look like when the bug is triggered:

```python
(Pdb) pp left_additional_properties['properties']['...']['properties']['id_to_action_map']['additionalProperties'] is left_additional_properties
True

(Pdb) pp right_additional_properties['properties']['...']['properties']['id_to_action_map']['additionalProperties'] is right_additional_properties
True

(Pdb) pp left_additional_properties['properties']['...']['properties']['id_to_action_map']['additionalProperties'] is right_additional_properties['properties']['...']['properties']['id_to_action_map']['additionalProperties']
False
```

These two dicts represent the same exact Swagger schema but Python's recursive dict equality check can't handle that the two cycle dicts are different objects, and doesn't "know" to stop the recursion.

The workaround here is to pre-process the dicts and replace any cycles with sentinels containing the path where the start of the cycle was first seen. Python's recursive dict equality will then work as expected.

Disclosure: I don't know very much about Swagger and I'm not totally sure if this covers all use-cases, though it does seem to fix the recent discovered issue. I'm definitely open to alternative suggestions.

I added regression tests which cause the RecursionError before my changes.