### PR TITLE
CORESERV-10844 Fix ChangedAdditionalPropertiesToFalse Rule

### DIFF
--- a/swagger_spec_compatibility/rules/changed_additional_properties_to_false.py
+++ b/swagger_spec_compatibility/rules/changed_additional_properties_to_false.py
@@ -34,5 +34,8 @@ class ChangedAdditionalPropertiesToFalse(BaseRule):
         for additional_properties_diff in AdditionalPropertiesDifferWalker(left_spec, right_spec).walk():
             if additional_properties_diff.diff_type != DiffType.VALUE:
                 continue
-            if getattr(getattr(additional_properties_diff, 'additionalProperties', {}), 'new', {}) is False:
+            if (
+                additional_properties_diff.additionalProperties is not None
+                and additional_properties_diff.additionalProperties.new is False
+            ):
                 yield cls.validation_message(format_path(additional_properties_diff.path))

--- a/swagger_spec_compatibility/rules/changed_additional_properties_to_false.py
+++ b/swagger_spec_compatibility/rules/changed_additional_properties_to_false.py
@@ -34,4 +34,5 @@ class ChangedAdditionalPropertiesToFalse(BaseRule):
         for additional_properties_diff in AdditionalPropertiesDifferWalker(left_spec, right_spec).walk():
             if additional_properties_diff.diff_type != DiffType.VALUE:
                 continue
-            yield cls.validation_message(format_path(additional_properties_diff.path))
+            if additional_properties_diff.additionalProperties.new == False:
+                yield cls.validation_message(format_path(additional_properties_diff.path))

--- a/swagger_spec_compatibility/rules/changed_additional_properties_to_false.py
+++ b/swagger_spec_compatibility/rules/changed_additional_properties_to_false.py
@@ -34,5 +34,5 @@ class ChangedAdditionalPropertiesToFalse(BaseRule):
         for additional_properties_diff in AdditionalPropertiesDifferWalker(left_spec, right_spec).walk():
             if additional_properties_diff.diff_type != DiffType.VALUE:
                 continue
-            if additional_properties_diff.additionalProperties.new == False:
+            if getattr(getattr(additional_properties_diff, 'additionalProperties', {}), 'new', {}) is False:
                 yield cls.validation_message(format_path(additional_properties_diff.path))

--- a/tests/rules/changed_additional_properties_to_false_test.py
+++ b/tests/rules/changed_additional_properties_to_false_test.py
@@ -151,11 +151,8 @@ def test_validate_succeeds_with_changes_to_additional_properties_objects(minimal
         'AnotherObject': {
             'type': 'object',
             'properties': {
-                'property_1': {'type': 'string'}
+                'property_1': {'type': 'string'},
             },
-            'required': [
-                'property_1',
-            ]
         },
     }
     old_spec_dict = dict(
@@ -173,13 +170,12 @@ def test_validate_succeeds_with_changes_to_additional_properties_objects(minimal
         'required': True,
         'schema': {
             'properties': {
-                'property_1': {'$ref': '#/definitions/ObjectThatRefersToAnotherObject'}
+                'property_1': {'$ref': '#/definitions/ObjectThatRefersToAnotherObject'},
             },
         },
     }]
     new_spec_dict = deepcopy(old_spec_dict)
     new_spec_dict['definitions']['AnotherObject']['properties']['property_2'] = {'type': 'string'}
-    new_spec_dict['definitions']['AnotherObject']['required'].append('property_2')
 
     old_spec = load_spec_from_spec_dict(old_spec_dict)
     new_spec = load_spec_from_spec_dict(new_spec_dict)

--- a/tests/rules/changed_additional_properties_to_false_test.py
+++ b/tests/rules/changed_additional_properties_to_false_test.py
@@ -143,6 +143,39 @@ def test_validate_return_an_error(
 
 
 def test_validate_succeeds_with_changes_to_additional_properties_objects(minimal_spec_dict, simple_operation_dict):
+    old_spec_dict = dict(
+        minimal_spec_dict,
+        paths={
+            '/endpoint': {
+                'get': simple_operation_dict,
+            },
+        },
+    )
+    old_spec_dict['paths']['/endpoint']['get']['parameters'] = [{
+        'in': 'body',
+        'name': 'body',
+        'required': True,
+        'schema': {
+            'properties': {
+                'property_1': {'type': 'string'},
+            },
+        },
+    }]
+    new_spec_dict = deepcopy(old_spec_dict)
+    new_spec_dict['paths']['/endpoint']['get']['parameters'][0]['schema']['properties']['property_2'] = {'type': 'string'}
+
+    old_spec = load_spec_from_spec_dict(old_spec_dict)
+    new_spec = load_spec_from_spec_dict(new_spec_dict)
+
+    assert list(
+        ChangedAdditionalPropertiesToFalse.validate(
+            left_spec=old_spec,
+            right_spec=new_spec,
+        ),
+    ) == []
+
+
+def test_validate_succeeds_with_changes_to_additional_properties_objects_behind_refs(minimal_spec_dict, simple_operation_dict):
     object_definitions = {
         'ObjectThatRefersToAnotherObject': {
             'additionalProperties': {'$ref': '#/definitions/AnotherObject'},

--- a/tests/rules/changed_additional_properties_to_false_test.py
+++ b/tests/rules/changed_additional_properties_to_false_test.py
@@ -140,3 +140,53 @@ def test_validate_return_an_error(
             right_spec=new_spec,
         ),
     ) == expected_results
+
+
+def test_validate_succeeds_with_changes_to_additional_properties_objects(minimal_spec_dict, simple_operation_dict):
+    object_definitions = {
+        'ObjectThatRefersToAnotherObject': {
+            'additionalProperties': {'$ref': '#/definitions/AnotherObject'},
+            'type': 'object',
+        },
+        'AnotherObject': {
+            'type': 'object',
+            'properties': {
+                'property_1': {'type': 'string'}
+            },
+            'required': [
+                'property_1',
+            ]
+        },
+    }
+    old_spec_dict = dict(
+        minimal_spec_dict,
+        paths={
+            '/endpoint': {
+                'get': simple_operation_dict,
+            },
+        },
+        definitions=object_definitions,
+    )
+    old_spec_dict['paths']['/endpoint']['get']['parameters'] = [{
+        'in': 'body',
+        'name': 'body',
+        'required': True,
+        'schema': {
+            'properties': {
+                'property_1': {'$ref': '#/definitions/ObjectThatRefersToAnotherObject'}
+            },
+        },
+    }]
+    new_spec_dict = deepcopy(old_spec_dict)
+    new_spec_dict['definitions']['AnotherObject']['properties']['property_2'] = {'type': 'string'}
+    new_spec_dict['definitions']['AnotherObject']['required'].append('property_2')
+
+    old_spec = load_spec_from_spec_dict(old_spec_dict)
+    new_spec = load_spec_from_spec_dict(new_spec_dict)
+
+    assert list(
+        ChangedAdditionalPropertiesToFalse.validate(
+            left_spec=old_spec,
+            right_spec=new_spec,
+        ),
+    ) == []


### PR DESCRIPTION
## Description
Fix the rule so that it only triggers when `additionalProperties` is set to `False` as the rule describes. Before this rule would trigger upon any change to `additionalProperties`, even if it's just a change in shape of an `additionalProperties` object which led to a lot of false alarms. `additionalProperties` can be an object, and changing it can be a backwards compatible operation.

## Notes for the reviewer
`additional_properties_diff.additionalProperties` has two fields, `old` and `new`. Those contain the `additionalProperties` values between the old spec and new spec respectively for a diff in an `additionalProperties` object.