### PR TITLE
run validate rules in parallel

### DIFF
--- a/swagger_spec_compatibility/rules/__init__.py
+++ b/swagger_spec_compatibility/rules/__init__.py
@@ -25,14 +25,14 @@ def validate_rules(
     rule,  # type: typing.Type[RuleProtocol]
 ):
     # type: (...) -> typing.Iterable[ValidationMessage]
-    return list(rule.validate(left_spec=old_spec, right_spec=new_spec))
+    return list(rule.validate(left_spec=old_spec, right_spec=new_spec))   # pragma: no cover
 
 
 def multi_run_wrapper(
     args,  # type: typing.Tuple[Spec, Spec, typing.Type[RuleProtocol]]
 ):
     # type: (...) -> typing.Iterable[ValidationMessage]
-    return validate_rules(*args)
+    return validate_rules(*args)   # pragma: no cover
 
 
 def compatibility_status(
@@ -47,13 +47,13 @@ def compatibility_status(
 
     rules_list = list(rules)
 
-    args = [
+    args_list = [
         (old_spec, new_spec, rule)
         for rule in rules_list
     ]
 
     pool = Pool(processes=4)
-    results = pool.map(multi_run_wrapper, args)
+    results = pool.map(multi_run_wrapper, args_list)
     pool.terminate()
 
     rules_to_error_level_mapping = {

--- a/tests/__main___test.py
+++ b/tests/__main___test.py
@@ -3,12 +3,16 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import json
+import os
+
 import mock
 import pytest
 
 from swagger_spec_compatibility import cli
 from swagger_spec_compatibility.__main__ import main
 from swagger_spec_compatibility.cli.common import add_rules_arguments
+from swagger_spec_compatibility.cli.common import uri
 from tests.conftest import DummyRule
 from tests.conftest import MOCKED_RULE_REGISTRY
 
@@ -33,9 +37,12 @@ def test_main_explain_succeed(mock_RuleRegistry, capsys):
     assert 'Rule description' in out
 
 
-def test_main_run_succeed(mock_SwaggerClient, mock_RuleRegistry_empty, capsys):
+def test_main_run_succeed(tmpdir, minimal_spec_dict, mock_RuleRegistry_empty, capsys):
+    spec_path = str(os.path.join(tmpdir.strpath, 'swagger.json'))
+    with open(spec_path, 'w') as f:
+        json.dump(minimal_spec_dict, f)
     mock_RuleRegistry_empty['DummyRule'] = DummyRule
-    assert main(['run', __file__, __file__]) == 0
+    assert main(['run', uri(spec_path), uri(spec_path)]) == 0
     capsys.readouterr()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -145,9 +145,3 @@ def mock_RuleRegistry():
 def mock_RuleRegistry_empty():
     with mock.patch.object(RuleRegistry, '_REGISTRY', {}) as m:  # type: typing.Dict[typing.Any, typing.Any]
         yield m
-
-
-@pytest.fixture
-def mock_SwaggerClient():
-    with mock.patch('swagger_spec_compatibility.spec_utils.SwaggerClient', autospec=True) as m:
-        yield m

--- a/tests/rules/__init___test.py
+++ b/tests/rules/__init___test.py
@@ -47,5 +47,4 @@ def test_compatibility_status_returns_no_issues_if_same_specs_defined_rules(
         new_spec=minimal_spec,
         rules=rules,
     )
-
     assert result == expected_result

--- a/tests/rules/__init___test.py
+++ b/tests/rules/__init___test.py
@@ -47,4 +47,5 @@ def test_compatibility_status_returns_no_issues_if_same_specs_defined_rules(
         new_spec=minimal_spec,
         rules=rules,
     )
+
     assert result == expected_result


### PR DESCRIPTION
run validate rules in parallel so that we can save lots of time

# Testing Done

```
$ old_spec_path=docs/source/rules/examples/REQ-E001/old.yaml
$ new_spec_path=docs/source/rules/examples/REQ-E001/new.yaml

$ python swagger_spec_compatibility/__main__.py run ${old_spec_path} ${new_spec_path}
ERROR rules:
	[REQ-E001] Added Required Property in Request contract: #/paths//endpoint/post/parameters/0/schema (documentation: https://swagger-spec-compatibility.readthedocs.io/en/latest/rules/REQ-E001.html)
```

test with biz_app swagger.json
```
 $ time python swagger_spec_compatibility/__main__.py run ${old_spec_path} ${new_spec_path}

real	1m25.693s
user	3m36.622s
sys	0m13.407s

on master
$ time python swagger_spec_compatibility/__main__.py run ${old_spec_path} ${new_spec_path}

real	3m40.959s
user	3m27.906s
sys	0m12.715s
```
make test passed
